### PR TITLE
fix(relay): bill reasoning tokens for non-standard OpenAI-compatible upstreams

### DIFF
--- a/relay/channel/openai/relay-openai.go
+++ b/relay/channel/openai/relay-openai.go
@@ -633,6 +633,16 @@ func applyUsagePostProcessing(info *relaycommon.RelayInfo, usage *dto.Usage, res
 			}
 		}
 	}
+
+	// Some OpenAI-compatible upstreams (e.g. exchangetoken) report completion_tokens
+	// EXCLUDING reasoning_tokens, with total = prompt + completion + reasoning —
+	// diverging from the OpenAI convention where completion includes reasoning. Fold
+	// the uncounted output (reasoning) into completion so it gets billed.
+	// No-op for standard upstreams (total == prompt+completion) and when total is
+	// unset/0. Invariant: billable output = total - prompt.
+	if usage.TotalTokens > usage.PromptTokens+usage.CompletionTokens {
+		usage.CompletionTokens = usage.TotalTokens - usage.PromptTokens
+	}
 }
 
 func extractCachedTokensFromBody(body []byte) (int, bool) {

--- a/relay/channel/openai/relay_openai_usage_test.go
+++ b/relay/channel/openai/relay_openai_usage_test.go
@@ -1,0 +1,75 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/stretchr/testify/require"
+)
+
+// Some OpenAI-compatible upstreams (observed: exchangetoken) return non-standard
+// usage where completion_tokens EXCLUDES reasoning_tokens and
+// total_tokens = prompt + completion + reasoning. Without normalization the
+// reasoning portion is silently dropped from billing.
+// Invariant we enforce: billable output = total - prompt.
+
+func TestApplyUsagePostProcessing_FoldsReasoningWhenTotalExceedsPromptPlusCompletion(t *testing.T) {
+	t.Parallel()
+
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelType: constant.ChannelTypeOpenAI,
+		},
+	}
+	usage := &dto.Usage{
+		PromptTokens:     17,
+		CompletionTokens: 330,
+		TotalTokens:      1468,
+	}
+
+	applyUsagePostProcessing(info, usage, nil)
+
+	require.Equal(t, 1451, usage.CompletionTokens, "completion should be folded to total-prompt (330 + 1121 reasoning)")
+	require.Equal(t, 17, usage.PromptTokens)
+	require.Equal(t, 1468, usage.TotalTokens)
+}
+
+func TestApplyUsagePostProcessing_NoopForStandardUsage(t *testing.T) {
+	t.Parallel()
+
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelType: constant.ChannelTypeOpenAI,
+		},
+	}
+	usage := &dto.Usage{
+		PromptTokens:     10,
+		CompletionTokens: 20,
+		TotalTokens:      30,
+	}
+
+	applyUsagePostProcessing(info, usage, nil)
+
+	require.Equal(t, 20, usage.CompletionTokens, "standard usage (total == prompt+completion) must not be altered")
+}
+
+func TestApplyUsagePostProcessing_NoopWhenTotalIsZero(t *testing.T) {
+	t.Parallel()
+
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelType: constant.ChannelTypeOpenAI,
+		},
+	}
+	usage := &dto.Usage{
+		PromptTokens:     10,
+		CompletionTokens: 20,
+		TotalTokens:      0,
+	}
+
+	applyUsagePostProcessing(info, usage, nil)
+
+	require.Equal(t, 20, usage.CompletionTokens, "missing/zero total_tokens must not trigger normalization")
+}


### PR DESCRIPTION
## Summary

- 修复 reasoning_tokens 漏计 — OpenAI 兼容上游（实测 exchangetoken）返回 `completion_tokens` 不含 reasoning、`total = prompt + completion + reasoning` 时，new-api 原样存储 completion ⇒ 自身配额 + LH 下游账单都丢掉 reasoning 部分（实测 1121/1451 ≈ 77% 输出漏计，go-live 阻塞）
- 在 `applyUsagePostProcessing` 末尾追加通用归一化：`if total > prompt+completion { completion = total - prompt }`，对标准上游 `total == prompt+completion` 与 `total=0` 都是 no-op
- TDD：3 个 unit test 覆盖 bug case / 标准 case / total=0 case

## Test plan

- [x] `go test ./relay/channel/openai/...` 全绿（含新加的 3 个 test）
- [x] 邻近回归扫描 `./relay/channel/gemini/... ./service/...` 全绿
- [x] `go build ./...` clean
- [x] 本地 dev 实例（裸 Go binary :3001）rebuild + graceful restart + `/api/status=200`，启动日志无 errors/panics
- [ ] canary 端到端验收：lh-canary 上 `/root/new-api/docker-compose.yml` 自建镜像 `new-api:lh-main` rebuild + `docker compose up -d new-api`；用 LH key 调 `POST https://launchhill.com/v1/chat/completions`（`gemini-3.1-pro-preview` + reasoning prompt），检查 LH statement `completionTokens ≈ total − prompt`（不再 ~330）

## Scope

- **仅合并到 `lh-main`**；是否回流 `main` / `wisemodel-main` / `feature/custom-extensions` 后续按需评估
- 纯计费逻辑补丁，不动品牌 / 署名 / 包路径（符合 Rule 5）

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)