### PR TITLE
refactor(web/payment): 采纳 upstream Tabs 外壳,fork 三 provider 嫁接为受控 tab

### DIFF
--- a/web/default/src/components/layout/components/section-page-layout.tsx
+++ b/web/default/src/components/layout/components/section-page-layout.tsx
@@ -33,11 +33,6 @@ function SectionPageLayoutTitle(_props: SlotProps) {
 }
 SectionPageLayoutTitle.displayName = 'SectionPageLayout.Title'
 
-function SectionPageLayoutDescription(_props: SlotProps) {
-  return null
-}
-SectionPageLayoutDescription.displayName = 'SectionPageLayout.Description'
-
 function SectionPageLayoutActions(_props: SlotProps) {
   return null
 }
@@ -64,7 +59,6 @@ export function SectionPageLayout(props: SectionPageLayoutProps) {
   )
 
   let title: ReactNode = null
-  let description: ReactNode = null
   let actions: ReactNode = null
   let content: ReactNode = null
   let breadcrumb: ReactNode = null
@@ -73,8 +67,6 @@ export function SectionPageLayout(props: SectionPageLayoutProps) {
     if (!isValidElement(node)) return
     const child = node as ReactElement<SlotProps>
     if (child.type === SectionPageLayoutTitle) title = child.props.children
-    else if (child.type === SectionPageLayoutDescription)
-      description = child.props.children
     else if (child.type === SectionPageLayoutActions)
       actions = child.props.children
     else if (child.type === SectionPageLayoutContent)
@@ -95,11 +87,6 @@ export function SectionPageLayout(props: SectionPageLayoutProps) {
               <h2 className='truncate text-base font-bold tracking-tight sm:text-lg'>
                 {title}
               </h2>
-              {description != null && (
-                <p className='text-muted-foreground mt-0.5 truncate text-sm'>
-                  {description}
-                </p>
-              )}
             </div>
             {actions != null && (
               <div className='flex shrink-0 flex-wrap items-center justify-end gap-2 sm:gap-x-4'>
@@ -129,7 +116,6 @@ export function SectionPageLayout(props: SectionPageLayoutProps) {
 }
 
 SectionPageLayout.Title = SectionPageLayoutTitle
-SectionPageLayout.Description = SectionPageLayoutDescription
 SectionPageLayout.Actions = SectionPageLayoutActions
 SectionPageLayout.Content = SectionPageLayoutContent
 SectionPageLayout.Breadcrumb = SectionPageLayoutBreadcrumb

--- a/web/default/src/features/platforms/index.tsx
+++ b/web/default/src/features/platforms/index.tsx
@@ -26,13 +26,13 @@ function PlatformsContent() {
     <>
       <SectionPageLayout>
         <SectionPageLayout.Title>{t('Platforms')}</SectionPageLayout.Title>
-        <SectionPageLayout.Description>
-          {t('Manage downstream platforms and their API credentials')}
-        </SectionPageLayout.Description>
         <SectionPageLayout.Actions>
           <PlatformsPrimaryButtons />
         </SectionPageLayout.Actions>
         <SectionPageLayout.Content>
+          <p className='text-muted-foreground mb-3 text-sm'>
+            {t('Manage downstream platforms and their API credentials')}
+          </p>
           <PlatformsTable />
         </SectionPageLayout.Content>
       </SectionPageLayout>

--- a/web/default/src/features/system-settings/components/settings-section.tsx
+++ b/web/default/src/features/system-settings/components/settings-section.tsx
@@ -22,7 +22,6 @@ import { useSuppressSettingsSectionHeader } from './settings-page-context'
 type SettingsSectionProps = {
   title: string
   titleProps?: React.HTMLAttributes<HTMLHeadingElement>
-  description?: string
   children: React.ReactNode
   className?: string
 }
@@ -30,7 +29,6 @@ type SettingsSectionProps = {
 export function SettingsSection({
   title,
   titleProps,
-  description,
   children,
   className,
 }: SettingsSectionProps) {
@@ -46,9 +44,6 @@ export function SettingsSection({
           >
             {title}
           </h3>
-          {description && (
-            <p className='text-muted-foreground text-sm'>{description}</p>
-          )}
         </div>
       )}
       {children}

--- a/web/default/src/features/system-settings/integrations/alipay-settings-section.tsx
+++ b/web/default/src/features/system-settings/integrations/alipay-settings-section.tsx
@@ -16,12 +16,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { useEffect, useState } from 'react'
-import { useForm } from 'react-hook-form'
-import { useQueryClient } from '@tanstack/react-query'
+import type { UseFormReturn } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import { toast } from 'sonner'
-import { Button } from '@/components/ui/button'
 import {
   Form,
   FormControl,
@@ -35,8 +31,8 @@ import { Input } from '@/components/ui/input'
 import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
 import { SettingsSection } from '../components/settings-section'
-import { useUpdateOption } from '../hooks/use-update-option'
 import { isMaskedSecret } from './paypal-settings-section'
+import type { PaymentFormValues } from './payment-settings-section'
 
 export interface AlipaySettingsValues {
   AlipayEnabled: boolean
@@ -49,119 +45,83 @@ export interface AlipaySettingsValues {
 }
 
 interface Props {
-  defaultValues: AlipaySettingsValues
+  form: UseFormReturn<PaymentFormValues>
   serverAddress?: string
 }
 
-export function AlipaySettingsSection({ defaultValues, serverAddress }: Props) {
+type AlipayUpdate = { key: string; value: string }
+
+/**
+ * Build option updates for Alipay using the same mask/changed guards as the
+ * original self-contained save. Credentials go in `options`; the Enabled switch
+ * is returned separately in `enable` so the caller persists it AFTER credentials
+ * (the backend rejects enable=true while credentials are empty).
+ */
+export function buildAlipayUpdates(
+  values: AlipaySettingsValues,
+  initial: AlipaySettingsValues
+): { options: AlipayUpdate[]; enable: AlipayUpdate | null } {
+  const options: AlipayUpdate[] = []
+
+  // AppId — plain field, only push when changed
+  if (values.AlipayAppId !== initial.AlipayAppId) {
+    options.push({ key: 'AlipayAppId', value: values.AlipayAppId || '' })
+  }
+
+  // Sensitive fields — only push if not masked (i.e., actually edited)
+  if (values.AlipayPrivateKey && !isMaskedSecret(values.AlipayPrivateKey)) {
+    options.push({ key: 'AlipayPrivateKey', value: values.AlipayPrivateKey })
+  }
+  if (values.AlipayPublicKey && !isMaskedSecret(values.AlipayPublicKey)) {
+    options.push({ key: 'AlipayPublicKey', value: values.AlipayPublicKey })
+  }
+
+  // SellerId — plain field, only push when changed
+  if (values.AlipaySellerId !== initial.AlipaySellerId) {
+    options.push({ key: 'AlipaySellerId', value: values.AlipaySellerId || '' })
+  }
+
+  if (initial.AlipayIsSandbox !== values.AlipayIsSandbox) {
+    options.push({
+      key: 'AlipayIsSandbox',
+      value: String(values.AlipayIsSandbox),
+    })
+  }
+
+  if (
+    values.AlipayMinTopUp !== undefined &&
+    values.AlipayMinTopUp !== null &&
+    values.AlipayMinTopUp !== initial.AlipayMinTopUp
+  ) {
+    options.push({
+      key: 'AlipayMinTopUp',
+      value: String(values.AlipayMinTopUp || 1),
+    })
+  }
+
+  // Enabled switch — persisted AFTER credentials by the caller.
+  let enable: AlipayUpdate | null = null
+  if (initial.AlipayEnabled !== values.AlipayEnabled) {
+    enable = { key: 'AlipayEnabled', value: String(values.AlipayEnabled) }
+  }
+
+  return { options, enable }
+}
+
+export function AlipaySettingsSection({ form, serverAddress }: Props) {
   const { t } = useTranslation()
-  const updateOption = useUpdateOption()
-  const queryClient = useQueryClient()
-  const [loading, setLoading] = useState(false)
-
-  const form = useForm<AlipaySettingsValues>({
-    defaultValues,
-  })
-
-  useEffect(() => {
-    form.reset(defaultValues)
-  }, [defaultValues, form])
 
   const notificationUrl = serverAddress
     ? `${serverAddress.replace(/\/+$/, '')}/api/user/alipay/notify`
     : `${t('Server Address')}/api/user/alipay/notify`
 
-  const handleSave = async () => {
-    setLoading(true)
-    try {
-      const values = form.getValues()
-      const options: { key: string; value: string }[] = []
-
-      // AppId — plain field, only push when changed
-      if (values.AlipayAppId !== defaultValues.AlipayAppId) {
-        options.push({ key: 'AlipayAppId', value: values.AlipayAppId || '' })
-      }
-
-      // Sensitive fields — only push if not masked (i.e., actually edited)
-      if (values.AlipayPrivateKey && !isMaskedSecret(values.AlipayPrivateKey)) {
-        options.push({
-          key: 'AlipayPrivateKey',
-          value: values.AlipayPrivateKey,
-        })
-      }
-      if (values.AlipayPublicKey && !isMaskedSecret(values.AlipayPublicKey)) {
-        options.push({ key: 'AlipayPublicKey', value: values.AlipayPublicKey })
-      }
-
-      // SellerId — plain field, only push when changed
-      if (values.AlipaySellerId !== defaultValues.AlipaySellerId) {
-        options.push({
-          key: 'AlipaySellerId',
-          value: values.AlipaySellerId || '',
-        })
-      }
-
-      if (defaultValues.AlipayIsSandbox !== values.AlipayIsSandbox) {
-        options.push({
-          key: 'AlipayIsSandbox',
-          value: String(values.AlipayIsSandbox),
-        })
-      }
-
-      if (
-        values.AlipayMinTopUp !== undefined &&
-        values.AlipayMinTopUp !== null &&
-        values.AlipayMinTopUp !== defaultValues.AlipayMinTopUp
-      ) {
-        options.push({
-          key: 'AlipayMinTopUp',
-          value: String(values.AlipayMinTopUp || 1),
-        })
-      }
-
-      // Enabled switch — saved AFTER credentials, because backend validation
-      // rejects enable=true when credentials are still empty
-      let enabledOption: { key: string; value: string } | null = null
-      if (defaultValues.AlipayEnabled !== values.AlipayEnabled) {
-        enabledOption = {
-          key: 'AlipayEnabled',
-          value: String(values.AlipayEnabled),
-        }
-      }
-
-      if (options.length === 0 && !enabledOption) {
-        toast.success(t('Updated successfully'))
-        setLoading(false)
-        return
-      }
-
-      for (const opt of options) {
-        await updateOption.mutateAsync(opt)
-      }
-      if (enabledOption) {
-        await updateOption.mutateAsync(enabledOption)
-      }
-      // Re-fetch options from the API. The backend strips sensitive fields
-      // (suffix Key/Secret/Token), so AlipayPrivateKey and AlipayPublicKey
-      // will come back empty. Non-sensitive fields like AlipayAppId,
-      // AlipaySellerId, AlipayIsSandbox, AlipayMinTopUp, AlipayEnabled
-      // will be re-populated with their saved values.
-      await queryClient.invalidateQueries({ queryKey: ['system-options'] })
-      toast.success(t('Updated successfully'))
-    } catch {
-      toast.error(t('Update failed'))
-    } finally {
-      setLoading(false)
-    }
-  }
-
   return (
-    <SettingsSection
-      title={t('Alipay Settings')}
-      description={t('Configure Alipay payment gateway for top-ups')}
-    >
+    <SettingsSection title={t('Alipay Settings')}>
+      <p className='text-muted-foreground text-sm'>
+        {t('Configure Alipay payment gateway for top-ups')}
+      </p>
       <Form {...form}>
-        <form className='space-y-4'>
+        <div className='space-y-4'>
           {/* Blue info box */}
           <div className='rounded-lg border border-blue-200 bg-blue-50 p-4 text-sm text-blue-900 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-100'>
             <p className='font-medium'>{t('Alipay Webhook Configuration:')}</p>
@@ -358,10 +318,7 @@ export function AlipaySettingsSection({ defaultValues, serverAddress }: Props) {
             />
           </div>
 
-          <Button type='button' onClick={handleSave} disabled={loading}>
-            {loading ? t('Saving...') : t('Save Alipay settings')}
-          </Button>
-        </form>
+        </div>
       </Form>
     </SettingsSection>
   )

--- a/web/default/src/features/system-settings/integrations/payment-settings-section.tsx
+++ b/web/default/src/features/system-settings/integrations/payment-settings-section.tsx
@@ -18,7 +18,7 @@ For commercial licensing, please contact support@quantumnous.com
 */
 import * as React from 'react'
 import * as z from 'zod'
-import { useForm } from 'react-hook-form'
+import { useForm, type Resolver } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { Code2, Eye, ShieldAlert } from 'lucide-react'
@@ -42,43 +42,70 @@ import {
   FormMessage,
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
-import { Separator } from '@/components/ui/separator'
 import { Switch } from '@/components/ui/switch'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Textarea } from '@/components/ui/textarea'
 import { RiskAcknowledgementDialog } from '@/components/risk-acknowledgement-dialog'
 import { confirmPaymentCompliance } from '../api'
+import {
+  SettingsForm,
+  SettingsSwitchContent,
+  SettingsSwitchItem,
+} from '../components/settings-form-layout'
+import { SettingsPageFormActions } from '../components/settings-page-context'
 import { SettingsSection } from '../components/settings-section'
 import { useUpdateOption } from '../hooks/use-update-option'
-import {
-  AlipaySettingsSection,
-  type AlipaySettingsValues,
-} from './alipay-settings-section'
+import { safeNumberFieldProps } from '../utils/numeric-field'
 import { AmountDiscountVisualEditor } from './amount-discount-visual-editor'
 import { AmountOptionsVisualEditor } from './amount-options-visual-editor'
 import { CreemProductsVisualEditor } from './creem-products-visual-editor'
 import { PaymentMethodsVisualEditor } from './payment-methods-visual-editor'
-import {
-  PayPalSettingsSection,
-  type PayPalSettingsValues,
-} from './paypal-settings-section'
 import {
   formatJsonForEditor,
   getJsonError,
   normalizeJsonForComparison,
   removeTrailingSlash,
 } from './utils'
+import { saveWaffoPancakeConfig } from './waffo-pancake-api'
 import {
   WaffoPancakeSettingsSection,
+  type WaffoPancakeBinding,
   type WaffoPancakeSettingsValues,
 } from './waffo-pancake-settings-section'
 import {
+  type PayMethod,
   WaffoSettingsSection,
   type WaffoSettingsValues,
 } from './waffo-settings-section'
 import {
+  AlipaySettingsSection,
+  buildAlipayUpdates,
+  type AlipaySettingsValues,
+} from './alipay-settings-section'
+import {
+  PayPalSettingsSection,
+  buildPayPalUpdates,
+  type PayPalSettingsValues,
+} from './paypal-settings-section'
+import {
   WxpaySettingsSection,
+  buildWxpayUpdates,
   type WxpaySettingsValues,
 } from './wxpay-settings-section'
+
+function isHttpOriginUrl(value: string) {
+  const trimmed = value.trim()
+  if (!trimmed) return true
+
+  try {
+    const url = new URL(trimmed)
+    const isHttpProtocol = url.protocol === 'http:' || url.protocol === 'https:'
+    const hasNoPath = url.pathname === '' || url.pathname === '/'
+    return isHttpProtocol && hasNoPath && !url.search && !url.hash
+  } catch {
+    return false
+  }
+}
 
 const paymentSchema = z.object({
   PayAddress: z.string().refine((value) => {
@@ -90,11 +117,12 @@ const paymentSchema = z.object({
   EpayKey: z.string(),
   Price: z.coerce.number().min(0),
   MinTopUp: z.coerce.number().min(0),
-  CustomCallbackAddress: z.string().refine((value) => {
-    const trimmed = value.trim()
-    if (!trimmed) return true
-    return /^https?:\/\//.test(trimmed)
-  }, 'Provide a valid URL starting with http:// or https://'),
+  CustomCallbackAddress: z
+    .string()
+    .refine(
+      isHttpOriginUrl,
+      'Enter only a top-level callback domain, for example https://api.example.com, without any path.'
+    ),
   PayMethods: z.string().superRefine((value, ctx) => {
     const error = getJsonError(value)
     if (error) {
@@ -144,11 +172,62 @@ const paymentSchema = z.object({
       })
     }
   }),
+  WaffoEnabled: z.boolean(),
+  WaffoApiKey: z.string(),
+  WaffoPrivateKey: z.string(),
+  WaffoPublicCert: z.string(),
+  WaffoSandboxPublicCert: z.string(),
+  WaffoSandboxApiKey: z.string(),
+  WaffoSandboxPrivateKey: z.string(),
+  WaffoSandbox: z.boolean(),
+  WaffoMerchantId: z.string(),
+  WaffoCurrency: z.string(),
+  WaffoUnitPrice: z.coerce.number().min(0),
+  WaffoMinTopUp: z.coerce.number().min(1),
+  WaffoNotifyUrl: z.string(),
+  WaffoReturnUrl: z.string(),
+  WaffoPancakeMerchantID: z.string(),
+  WaffoPancakePrivateKey: z.string(),
+  WaffoPancakeReturnURL: z.string(),
+  // Alipay (ours-only provider, controlled via this parent form)
+  AlipayEnabled: z.boolean(),
+  AlipayAppId: z.string(),
+  AlipayPrivateKey: z.string(),
+  AlipayPublicKey: z.string(),
+  AlipaySellerId: z.string(),
+  AlipayIsSandbox: z.boolean(),
+  AlipayMinTopUp: z.coerce.number().min(1),
+  // WeChat Pay (ours-only provider)
+  WxpayEnabled: z.boolean(),
+  WxpayAppId: z.string(),
+  WxpayMchId: z.string(),
+  WxpayMchSerialNo: z.string(),
+  WxpayApiV3Key: z.string(),
+  WxpayPrivateKey: z.string(),
+  WxpayPublicKeyId: z.string(),
+  WxpayPublicKey: z.string(),
+  WxpayMinTopUp: z.coerce.number().min(1),
+  // PayPal (ours-only provider)
+  PayPalClientId: z.string(),
+  PayPalClientSecret: z.string(),
+  PayPalWebhookSecret: z.string(),
+  PayPalMode: z.string(),
+  PayPalMinTopUp: z.coerce.number().min(1),
 })
 
-type PaymentFormValues = z.infer<typeof paymentSchema>
+export type PaymentFormValues = z.infer<typeof paymentSchema>
+type WaffoFormFieldValues = Omit<WaffoSettingsValues, 'WaffoPayMethods'>
+type PaymentBaseFormValues = Omit<
+  PaymentFormValues,
+  | keyof WaffoFormFieldValues
+  | keyof WaffoPancakeSettingsValues
+  | keyof AlipaySettingsValues
+  | keyof WxpaySettingsValues
+  | keyof PayPalSettingsValues
+>
 
 const CURRENT_COMPLIANCE_TERMS_VERSION = 'v1'
+const paymentTabContentClassName = 'mt-6 min-w-0'
 
 type PaymentComplianceDefaults = {
   confirmed: boolean
@@ -158,7 +237,7 @@ type PaymentComplianceDefaults = {
 }
 
 type PaymentSettingsSectionProps = {
-  defaultValues: PaymentFormValues
+  defaultValues: PaymentBaseFormValues
   waffoDefaultValues: WaffoSettingsValues
   waffoPancakeDefaultValues: WaffoPancakeSettingsValues
   waffoPancakeProvisionedStoreID?: string
@@ -168,6 +247,15 @@ type PaymentSettingsSectionProps = {
   alipayDefaultValues: AlipaySettingsValues
   wxpayDefaultValues: WxpaySettingsValues
   serverAddress?: string
+}
+
+function parseWaffoPayMethods(value: string): PayMethod[] {
+  try {
+    const parsed = JSON.parse(value || '[]')
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
 }
 
 export function PaymentSettingsSection({
@@ -185,10 +273,28 @@ export function PaymentSettingsSection({
   const { t } = useTranslation()
   const queryClient = useQueryClient()
   const updateOption = useUpdateOption()
-  const initialRef = React.useRef(defaultValues)
+  const initialFormValues = React.useMemo<PaymentFormValues>(
+    () => ({
+      ...defaultValues,
+      ...waffoDefaultValues,
+      ...waffoPancakeDefaultValues,
+      ...alipayDefaultValues,
+      ...wxpayDefaultValues,
+      ...paypalDefaultValues,
+    }),
+    [
+      defaultValues,
+      waffoDefaultValues,
+      waffoPancakeDefaultValues,
+      alipayDefaultValues,
+      wxpayDefaultValues,
+      paypalDefaultValues,
+    ]
+  )
+  const initialRef = React.useRef(initialFormValues)
   const defaultsSignature = React.useMemo(
-    () => JSON.stringify(defaultValues),
-    [defaultValues]
+    () => JSON.stringify(initialFormValues),
+    [initialFormValues]
   )
 
   const [payMethodsVisualMode, setPayMethodsVisualMode] = React.useState(true)
@@ -199,6 +305,32 @@ export function PaymentSettingsSection({
   const [creemProductsVisualMode, setCreemProductsVisualMode] =
     React.useState(true)
   const [showComplianceDialog, setShowComplianceDialog] = React.useState(false)
+  const [waffoPayMethods, setWaffoPayMethods] = React.useState<PayMethod[]>(
+    () => parseWaffoPayMethods(waffoDefaultValues.WaffoPayMethods)
+  )
+  const [waffoPancakeSelection, setWaffoPancakeSelection] =
+    React.useState<WaffoPancakeBinding>({
+      storeID: waffoPancakeProvisionedStoreID ?? '',
+      productID: waffoPancakeProvisionedProductID ?? '',
+    })
+  const [waffoPancakeSavedBinding, setWaffoPancakeSavedBinding] =
+    React.useState<WaffoPancakeBinding>({
+      storeID: waffoPancakeProvisionedStoreID ?? '',
+      productID: waffoPancakeProvisionedProductID ?? '',
+    })
+
+  React.useEffect(() => {
+    setWaffoPayMethods(parseWaffoPayMethods(waffoDefaultValues.WaffoPayMethods))
+  }, [waffoDefaultValues.WaffoPayMethods])
+
+  React.useEffect(() => {
+    const nextBinding = {
+      storeID: waffoPancakeProvisionedStoreID ?? '',
+      productID: waffoPancakeProvisionedProductID ?? '',
+    }
+    setWaffoPancakeSelection(nextBinding)
+    setWaffoPancakeSavedBinding(nextBinding)
+  }, [waffoPancakeProvisionedProductID, waffoPancakeProvisionedStoreID])
 
   const complianceStatements = React.useMemo(
     () => [
@@ -274,17 +406,62 @@ export function PaymentSettingsSection({
     },
   })
 
-  const form = useForm({
-    resolver: zodResolver(paymentSchema),
+  const form = useForm<PaymentFormValues>({
+    resolver: zodResolver(paymentSchema) as Resolver<PaymentFormValues>,
     mode: 'onChange', // Enable real-time validation
     defaultValues: {
-      ...defaultValues,
-      PayMethods: formatJsonForEditor(defaultValues.PayMethods),
-      AmountOptions: formatJsonForEditor(defaultValues.AmountOptions),
-      AmountDiscount: formatJsonForEditor(defaultValues.AmountDiscount),
-      CreemProducts: formatJsonForEditor(defaultValues.CreemProducts),
+      ...initialFormValues,
+      PayMethods: formatJsonForEditor(initialFormValues.PayMethods),
+      AmountOptions: formatJsonForEditor(initialFormValues.AmountOptions),
+      AmountDiscount: formatJsonForEditor(initialFormValues.AmountDiscount),
+      CreemProducts: formatJsonForEditor(initialFormValues.CreemProducts),
     },
   })
+
+  const { isSubmitting } = form.formState
+
+  const setPaymentValue = React.useCallback(
+    (
+      key: keyof PaymentFormValues,
+      value: PaymentFormValues[keyof PaymentFormValues]
+    ) => {
+      form.setValue(
+        key as Parameters<typeof form.setValue>[0],
+        value as Parameters<typeof form.setValue>[1],
+        {
+          shouldDirty: true,
+          shouldValidate: true,
+        }
+      )
+    },
+    [form]
+  )
+
+  const setWaffoValue = React.useCallback(
+    <K extends keyof WaffoFormFieldValues>(
+      key: K,
+      value: WaffoFormFieldValues[K]
+    ) => {
+      setPaymentValue(
+        key as keyof PaymentFormValues,
+        value as PaymentFormValues[keyof PaymentFormValues]
+      )
+    },
+    [setPaymentValue]
+  )
+
+  const setWaffoPancakeValue = React.useCallback(
+    <K extends keyof WaffoPancakeSettingsValues>(
+      key: K,
+      value: WaffoPancakeSettingsValues[K]
+    ) => {
+      setPaymentValue(
+        key as keyof PaymentFormValues,
+        value as PaymentFormValues[keyof PaymentFormValues]
+      )
+    },
+    [setPaymentValue]
+  )
 
   React.useEffect(() => {
     const parsedDefaults = JSON.parse(defaultsSignature) as PaymentFormValues
@@ -298,25 +475,109 @@ export function PaymentSettingsSection({
     })
   }, [defaultsSignature, form])
 
-  const saveGeneralSettings = async () => {
-    const values = form.getValues()
+  const onSubmit = async (values: PaymentFormValues) => {
     const sanitized = {
-      Price: values.Price as number,
-      MinTopUp: values.MinTopUp as number,
+      PayAddress: removeTrailingSlash(values.PayAddress),
+      EpayId: values.EpayId.trim(),
+      EpayKey: values.EpayKey.trim(),
+      Price: values.Price,
+      MinTopUp: values.MinTopUp,
+      CustomCallbackAddress: removeTrailingSlash(values.CustomCallbackAddress),
       PayMethods: values.PayMethods.trim(),
       AmountOptions: values.AmountOptions.trim(),
       AmountDiscount: values.AmountDiscount.trim(),
+      StripeApiSecret: values.StripeApiSecret.trim(),
+      StripeWebhookSecret: values.StripeWebhookSecret.trim(),
+      StripePriceId: values.StripePriceId.trim(),
+      StripeUnitPrice: values.StripeUnitPrice,
+      StripeMinTopUp: values.StripeMinTopUp,
+      StripePromotionCodesEnabled: values.StripePromotionCodesEnabled,
+      CreemApiKey: values.CreemApiKey.trim(),
+      CreemWebhookSecret: values.CreemWebhookSecret.trim(),
+      CreemTestMode: values.CreemTestMode,
+      CreemProducts: values.CreemProducts.trim(),
+      WaffoEnabled: values.WaffoEnabled,
+      WaffoSandbox: values.WaffoSandbox,
+      WaffoMerchantId: values.WaffoMerchantId.trim(),
+      WaffoCurrency: values.WaffoCurrency.trim() || 'USD',
+      WaffoUnitPrice: values.WaffoUnitPrice,
+      WaffoMinTopUp: values.WaffoMinTopUp,
+      WaffoNotifyUrl: values.WaffoNotifyUrl.trim(),
+      WaffoReturnUrl: values.WaffoReturnUrl.trim(),
+      WaffoPublicCert: values.WaffoPublicCert.trim(),
+      WaffoSandboxPublicCert: values.WaffoSandboxPublicCert.trim(),
+      WaffoApiKey: values.WaffoApiKey.trim(),
+      WaffoPrivateKey: values.WaffoPrivateKey.trim(),
+      WaffoSandboxApiKey: values.WaffoSandboxApiKey.trim(),
+      WaffoSandboxPrivateKey: values.WaffoSandboxPrivateKey.trim(),
+      WaffoPayMethods: JSON.stringify(waffoPayMethods),
+      WaffoPancakeMerchantID: values.WaffoPancakeMerchantID.trim(),
+      WaffoPancakePrivateKey: values.WaffoPancakePrivateKey.trim(),
+      WaffoPancakeReturnURL: removeTrailingSlash(
+        values.WaffoPancakeReturnURL.trim()
+      ),
     }
 
     const initial = {
+      PayAddress: removeTrailingSlash(initialRef.current.PayAddress),
+      EpayId: initialRef.current.EpayId.trim(),
+      EpayKey: initialRef.current.EpayKey.trim(),
       Price: initialRef.current.Price,
       MinTopUp: initialRef.current.MinTopUp,
+      CustomCallbackAddress: removeTrailingSlash(
+        initialRef.current.CustomCallbackAddress
+      ),
       PayMethods: initialRef.current.PayMethods.trim(),
       AmountOptions: initialRef.current.AmountOptions.trim(),
       AmountDiscount: initialRef.current.AmountDiscount.trim(),
+      StripeApiSecret: initialRef.current.StripeApiSecret.trim(),
+      StripeWebhookSecret: initialRef.current.StripeWebhookSecret.trim(),
+      StripePriceId: initialRef.current.StripePriceId.trim(),
+      StripeUnitPrice: initialRef.current.StripeUnitPrice,
+      StripeMinTopUp: initialRef.current.StripeMinTopUp,
+      StripePromotionCodesEnabled:
+        initialRef.current.StripePromotionCodesEnabled,
+      CreemApiKey: initialRef.current.CreemApiKey.trim(),
+      CreemWebhookSecret: initialRef.current.CreemWebhookSecret.trim(),
+      CreemTestMode: initialRef.current.CreemTestMode,
+      CreemProducts: initialRef.current.CreemProducts.trim(),
+      WaffoEnabled: initialRef.current.WaffoEnabled,
+      WaffoSandbox: initialRef.current.WaffoSandbox,
+      WaffoMerchantId: initialRef.current.WaffoMerchantId.trim(),
+      WaffoCurrency: initialRef.current.WaffoCurrency.trim() || 'USD',
+      WaffoUnitPrice: initialRef.current.WaffoUnitPrice,
+      WaffoMinTopUp: initialRef.current.WaffoMinTopUp,
+      WaffoNotifyUrl: initialRef.current.WaffoNotifyUrl.trim(),
+      WaffoReturnUrl: initialRef.current.WaffoReturnUrl.trim(),
+      WaffoPublicCert: initialRef.current.WaffoPublicCert.trim(),
+      WaffoSandboxPublicCert: initialRef.current.WaffoSandboxPublicCert.trim(),
+      WaffoApiKey: initialRef.current.WaffoApiKey.trim(),
+      WaffoPrivateKey: initialRef.current.WaffoPrivateKey.trim(),
+      WaffoSandboxApiKey: initialRef.current.WaffoSandboxApiKey.trim(),
+      WaffoSandboxPrivateKey: initialRef.current.WaffoSandboxPrivateKey.trim(),
+      WaffoPayMethods: JSON.stringify(
+        parseWaffoPayMethods(waffoDefaultValues.WaffoPayMethods)
+      ),
+      WaffoPancakeMerchantID: initialRef.current.WaffoPancakeMerchantID.trim(),
+      WaffoPancakePrivateKey: initialRef.current.WaffoPancakePrivateKey.trim(),
+      WaffoPancakeReturnURL: removeTrailingSlash(
+        initialRef.current.WaffoPancakeReturnURL.trim()
+      ),
     }
 
-    const updates: Array<{ key: string; value: string | number }> = []
+    const updates: Array<{ key: string; value: string | number | boolean }> = []
+
+    if (sanitized.PayAddress !== initial.PayAddress) {
+      updates.push({ key: 'PayAddress', value: sanitized.PayAddress })
+    }
+
+    if (sanitized.EpayId !== initial.EpayId) {
+      updates.push({ key: 'EpayId', value: sanitized.EpayId })
+    }
+
+    if (sanitized.EpayKey && sanitized.EpayKey !== initial.EpayKey) {
+      updates.push({ key: 'EpayKey', value: sanitized.EpayKey })
+    }
 
     if (sanitized.Price !== initial.Price) {
       updates.push({ key: 'Price', value: sanitized.Price })
@@ -324,6 +585,13 @@ export function PaymentSettingsSection({
 
     if (sanitized.MinTopUp !== initial.MinTopUp) {
       updates.push({ key: 'MinTopUp', value: sanitized.MinTopUp })
+    }
+
+    if (sanitized.CustomCallbackAddress !== initial.CustomCallbackAddress) {
+      updates.push({
+        key: 'CustomCallbackAddress',
+        value: sanitized.CustomCallbackAddress,
+      })
     }
 
     if (
@@ -352,87 +620,6 @@ export function PaymentSettingsSection({
         value: sanitized.AmountDiscount,
       })
     }
-
-    if (updates.length === 0) {
-      return
-    }
-
-    for (const update of updates) {
-      await updateOption.mutateAsync(update)
-    }
-  }
-
-  const saveEpaySettings = async () => {
-    const values = form.getValues()
-    const sanitized = {
-      PayAddress: removeTrailingSlash(values.PayAddress),
-      EpayId: values.EpayId.trim(),
-      EpayKey: values.EpayKey.trim(),
-      CustomCallbackAddress: removeTrailingSlash(values.CustomCallbackAddress),
-    }
-
-    const initial = {
-      PayAddress: removeTrailingSlash(initialRef.current.PayAddress),
-      EpayId: initialRef.current.EpayId.trim(),
-      EpayKey: initialRef.current.EpayKey.trim(),
-      CustomCallbackAddress: removeTrailingSlash(
-        initialRef.current.CustomCallbackAddress
-      ),
-    }
-
-    const updates: Array<{ key: string; value: string }> = []
-
-    if (sanitized.PayAddress !== initial.PayAddress) {
-      updates.push({ key: 'PayAddress', value: sanitized.PayAddress })
-    }
-
-    if (sanitized.EpayId !== initial.EpayId) {
-      updates.push({ key: 'EpayId', value: sanitized.EpayId })
-    }
-
-    if (sanitized.EpayKey && sanitized.EpayKey !== initial.EpayKey) {
-      updates.push({ key: 'EpayKey', value: sanitized.EpayKey })
-    }
-
-    if (sanitized.CustomCallbackAddress !== initial.CustomCallbackAddress) {
-      updates.push({
-        key: 'CustomCallbackAddress',
-        value: sanitized.CustomCallbackAddress,
-      })
-    }
-
-    if (updates.length === 0) {
-      return
-    }
-
-    for (const update of updates) {
-      await updateOption.mutateAsync(update)
-    }
-  }
-
-  const saveStripeSettings = async () => {
-    const values = form.getValues()
-    const sanitized = {
-      StripeApiSecret: values.StripeApiSecret.trim(),
-      StripeWebhookSecret: values.StripeWebhookSecret.trim(),
-      StripePriceId: values.StripePriceId.trim(),
-      StripeUnitPrice: values.StripeUnitPrice as number,
-      StripeMinTopUp: values.StripeMinTopUp as number,
-      StripePromotionCodesEnabled:
-        values.StripePromotionCodesEnabled as boolean,
-    }
-
-    const initial = {
-      StripeApiSecret: initialRef.current.StripeApiSecret.trim(),
-      StripeWebhookSecret: initialRef.current.StripeWebhookSecret.trim(),
-      StripePriceId: initialRef.current.StripePriceId.trim(),
-      StripeUnitPrice: initialRef.current.StripeUnitPrice,
-      StripeMinTopUp: initialRef.current.StripeMinTopUp,
-      StripePromotionCodesEnabled:
-        initialRef.current.StripePromotionCodesEnabled,
-    }
-
-    const updates: Array<{ key: string; value: string | number | boolean }> = []
 
     if (
       sanitized.StripeApiSecret &&
@@ -472,33 +659,6 @@ export function PaymentSettingsSection({
         value: sanitized.StripePromotionCodesEnabled,
       })
     }
-
-    if (updates.length === 0) {
-      return
-    }
-
-    for (const update of updates) {
-      await updateOption.mutateAsync(update)
-    }
-  }
-
-  const saveCreemSettings = async () => {
-    const values = form.getValues()
-    const sanitized = {
-      CreemApiKey: values.CreemApiKey.trim(),
-      CreemWebhookSecret: values.CreemWebhookSecret.trim(),
-      CreemTestMode: values.CreemTestMode as boolean,
-      CreemProducts: values.CreemProducts.trim(),
-    }
-
-    const initial = {
-      CreemApiKey: initialRef.current.CreemApiKey.trim(),
-      CreemWebhookSecret: initialRef.current.CreemWebhookSecret.trim(),
-      CreemTestMode: initialRef.current.CreemTestMode,
-      CreemProducts: initialRef.current.CreemProducts.trim(),
-    }
-
-    const updates: Array<{ key: string; value: string | boolean }> = []
 
     if (
       sanitized.CreemApiKey &&
@@ -528,162 +688,190 @@ export function PaymentSettingsSection({
       updates.push({ key: 'CreemProducts', value: sanitized.CreemProducts })
     }
 
-    if (updates.length === 0) {
+    if (sanitized.WaffoEnabled !== initial.WaffoEnabled) {
+      updates.push({ key: 'WaffoEnabled', value: sanitized.WaffoEnabled })
+    }
+
+    if (sanitized.WaffoSandbox !== initial.WaffoSandbox) {
+      updates.push({ key: 'WaffoSandbox', value: sanitized.WaffoSandbox })
+    }
+
+    if (sanitized.WaffoMerchantId !== initial.WaffoMerchantId) {
+      updates.push({ key: 'WaffoMerchantId', value: sanitized.WaffoMerchantId })
+    }
+
+    if (sanitized.WaffoCurrency !== initial.WaffoCurrency) {
+      updates.push({ key: 'WaffoCurrency', value: sanitized.WaffoCurrency })
+    }
+
+    if (sanitized.WaffoUnitPrice !== initial.WaffoUnitPrice) {
+      updates.push({ key: 'WaffoUnitPrice', value: sanitized.WaffoUnitPrice })
+    }
+
+    if (sanitized.WaffoMinTopUp !== initial.WaffoMinTopUp) {
+      updates.push({ key: 'WaffoMinTopUp', value: sanitized.WaffoMinTopUp })
+    }
+
+    if (sanitized.WaffoNotifyUrl !== initial.WaffoNotifyUrl) {
+      updates.push({ key: 'WaffoNotifyUrl', value: sanitized.WaffoNotifyUrl })
+    }
+
+    if (sanitized.WaffoReturnUrl !== initial.WaffoReturnUrl) {
+      updates.push({ key: 'WaffoReturnUrl', value: sanitized.WaffoReturnUrl })
+    }
+
+    if (sanitized.WaffoPublicCert !== initial.WaffoPublicCert) {
+      updates.push({ key: 'WaffoPublicCert', value: sanitized.WaffoPublicCert })
+    }
+
+    if (sanitized.WaffoSandboxPublicCert !== initial.WaffoSandboxPublicCert) {
+      updates.push({
+        key: 'WaffoSandboxPublicCert',
+        value: sanitized.WaffoSandboxPublicCert,
+      })
+    }
+
+    if (sanitized.WaffoApiKey) {
+      updates.push({ key: 'WaffoApiKey', value: sanitized.WaffoApiKey })
+    }
+
+    if (sanitized.WaffoPrivateKey) {
+      updates.push({ key: 'WaffoPrivateKey', value: sanitized.WaffoPrivateKey })
+    }
+
+    if (sanitized.WaffoSandboxApiKey) {
+      updates.push({
+        key: 'WaffoSandboxApiKey',
+        value: sanitized.WaffoSandboxApiKey,
+      })
+    }
+
+    if (sanitized.WaffoSandboxPrivateKey) {
+      updates.push({
+        key: 'WaffoSandboxPrivateKey',
+        value: sanitized.WaffoSandboxPrivateKey,
+      })
+    }
+
+    if (
+      normalizeJsonForComparison(sanitized.WaffoPayMethods) !==
+      normalizeJsonForComparison(initial.WaffoPayMethods)
+    ) {
+      updates.push({ key: 'WaffoPayMethods', value: sanitized.WaffoPayMethods })
+    }
+
+    // ours-only providers (Alipay / WeChat Pay / PayPal). Each builder applies
+    // its own mask/changed guards verbatim; credentials are queued here and the
+    // Enabled switch (if any) is appended last so it is saved after credentials
+    // (backend rejects enable=true while credentials are empty).
+    const alipayResult = buildAlipayUpdates(values, initialRef.current)
+    const wxpayResult = buildWxpayUpdates(values, initialRef.current)
+    const paypalResult = buildPayPalUpdates(values)
+    updates.push(
+      ...alipayResult.options,
+      ...wxpayResult.options,
+      ...paypalResult.options
+    )
+    if (alipayResult.enable) updates.push(alipayResult.enable)
+    if (wxpayResult.enable) updates.push(wxpayResult.enable)
+
+    const hasWaffoPancakeChanges =
+      sanitized.WaffoPancakeMerchantID !== initial.WaffoPancakeMerchantID ||
+      sanitized.WaffoPancakePrivateKey.length > 0 ||
+      sanitized.WaffoPancakeReturnURL !== initial.WaffoPancakeReturnURL ||
+      waffoPancakeSelection.storeID !== waffoPancakeSavedBinding.storeID ||
+      waffoPancakeSelection.productID !== waffoPancakeSavedBinding.productID
+
+    if (updates.length === 0 && !hasWaffoPancakeChanges) {
+      toast.info(t('No changes to save'))
       return
     }
 
     for (const update of updates) {
       await updateOption.mutateAsync(update)
     }
+
+    if (!hasWaffoPancakeChanges) {
+      return
+    }
+
+    if (!sanitized.WaffoPancakeMerchantID) {
+      toast.error(t('Merchant ID is required'))
+      return
+    }
+
+    if (!waffoPancakeSelection.storeID || !waffoPancakeSelection.productID) {
+      toast.error(t('Pick or create both a store and a product before saving.'))
+      return
+    }
+
+    try {
+      const body = await saveWaffoPancakeConfig({
+        merchantID: sanitized.WaffoPancakeMerchantID,
+        privateKey: sanitized.WaffoPancakePrivateKey,
+        returnURL: sanitized.WaffoPancakeReturnURL,
+        storeID: waffoPancakeSelection.storeID,
+        productID: waffoPancakeSelection.productID,
+      })
+
+      if (
+        body?.message === 'success' &&
+        typeof body.data === 'object' &&
+        body.data
+      ) {
+        const saved = body.data as { product_id: string; store_id: string }
+        const savedBinding = {
+          storeID: saved.store_id,
+          productID: saved.product_id,
+        }
+        setWaffoPancakeSavedBinding(savedBinding)
+        setWaffoPancakeSelection(savedBinding)
+        queryClient.invalidateQueries({ queryKey: ['system-options'] })
+        toast.success(t('Waffo Pancake settings saved'))
+        return
+      }
+
+      const reason = typeof body?.data === 'string' ? body.data : undefined
+      toast.error(
+        reason
+          ? `${t('Waffo Pancake save failed')}: ${reason}`
+          : t('Waffo Pancake save failed')
+      )
+    } catch (error) {
+      toast.error(
+        `${t('Waffo Pancake save failed')}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      )
+    }
   }
 
-  const onSubmit = async (values: PaymentFormValues) => {
-    const sanitized = {
-      PayAddress: removeTrailingSlash(values.PayAddress),
-      EpayId: values.EpayId.trim(),
-      EpayKey: values.EpayKey.trim(),
-      Price: values.Price,
-      MinTopUp: values.MinTopUp,
-      CustomCallbackAddress: removeTrailingSlash(values.CustomCallbackAddress),
-      PayMethods: values.PayMethods.trim(),
-      AmountOptions: values.AmountOptions.trim(),
-      AmountDiscount: values.AmountDiscount.trim(),
-      StripeApiSecret: values.StripeApiSecret.trim(),
-      StripeWebhookSecret: values.StripeWebhookSecret.trim(),
-      StripePriceId: values.StripePriceId.trim(),
-      StripeUnitPrice: values.StripeUnitPrice,
-      StripeMinTopUp: values.StripeMinTopUp,
-      StripePromotionCodesEnabled: values.StripePromotionCodesEnabled,
-    }
-
-    const initial = {
-      PayAddress: removeTrailingSlash(initialRef.current.PayAddress),
-      EpayId: initialRef.current.EpayId.trim(),
-      EpayKey: initialRef.current.EpayKey.trim(),
-      Price: initialRef.current.Price,
-      MinTopUp: initialRef.current.MinTopUp,
-      CustomCallbackAddress: removeTrailingSlash(
-        initialRef.current.CustomCallbackAddress
-      ),
-      PayMethods: initialRef.current.PayMethods.trim(),
-      AmountOptions: initialRef.current.AmountOptions.trim(),
-      AmountDiscount: initialRef.current.AmountDiscount.trim(),
-      StripeApiSecret: initialRef.current.StripeApiSecret.trim(),
-      StripeWebhookSecret: initialRef.current.StripeWebhookSecret.trim(),
-      StripePriceId: initialRef.current.StripePriceId.trim(),
-      StripeUnitPrice: initialRef.current.StripeUnitPrice,
-      StripeMinTopUp: initialRef.current.StripeMinTopUp,
-      StripePromotionCodesEnabled:
-        initialRef.current.StripePromotionCodesEnabled,
-    }
-
-    const updates: Array<{ key: string; value: string | number | boolean }> = []
-
-    if (sanitized.PayAddress !== initial.PayAddress) {
-      updates.push({ key: 'PayAddress', value: sanitized.PayAddress })
-    }
-
-    if (sanitized.EpayId !== initial.EpayId) {
-      updates.push({ key: 'EpayId', value: sanitized.EpayId })
-    }
-
-    if (sanitized.EpayKey && sanitized.EpayKey !== initial.EpayKey) {
-      updates.push({ key: 'EpayKey', value: sanitized.EpayKey })
-    }
-
-    if (sanitized.Price !== initial.Price) {
-      updates.push({ key: 'Price', value: sanitized.Price })
-    }
-
-    if (sanitized.MinTopUp !== initial.MinTopUp) {
-      updates.push({ key: 'MinTopUp', value: sanitized.MinTopUp })
-    }
-
-    if (sanitized.CustomCallbackAddress !== initial.CustomCallbackAddress) {
-      updates.push({
-        key: 'CustomCallbackAddress',
-        value: sanitized.CustomCallbackAddress,
-      })
-    }
-
-    if (
-      normalizeJsonForComparison(sanitized.PayMethods) !==
-      normalizeJsonForComparison(initial.PayMethods)
-    ) {
-      updates.push({ key: 'PayMethods', value: sanitized.PayMethods })
-    }
-
-    if (
-      normalizeJsonForComparison(sanitized.AmountOptions) !==
-      normalizeJsonForComparison(initial.AmountOptions)
-    ) {
-      updates.push({
-        key: 'payment_setting.amount_options',
-        value: sanitized.AmountOptions,
-      })
-    }
-
-    if (
-      normalizeJsonForComparison(sanitized.AmountDiscount) !==
-      normalizeJsonForComparison(initial.AmountDiscount)
-    ) {
-      updates.push({
-        key: 'payment_setting.amount_discount',
-        value: sanitized.AmountDiscount,
-      })
-    }
-
-    if (
-      sanitized.StripeApiSecret &&
-      sanitized.StripeApiSecret !== initial.StripeApiSecret
-    ) {
-      updates.push({ key: 'StripeApiSecret', value: sanitized.StripeApiSecret })
-    }
-
-    if (
-      sanitized.StripeWebhookSecret &&
-      sanitized.StripeWebhookSecret !== initial.StripeWebhookSecret
-    ) {
-      updates.push({
-        key: 'StripeWebhookSecret',
-        value: sanitized.StripeWebhookSecret,
-      })
-    }
-
-    if (sanitized.StripePriceId !== initial.StripePriceId) {
-      updates.push({ key: 'StripePriceId', value: sanitized.StripePriceId })
-    }
-
-    if (sanitized.StripeUnitPrice !== initial.StripeUnitPrice) {
-      updates.push({ key: 'StripeUnitPrice', value: sanitized.StripeUnitPrice })
-    }
-
-    if (sanitized.StripeMinTopUp !== initial.StripeMinTopUp) {
-      updates.push({ key: 'StripeMinTopUp', value: sanitized.StripeMinTopUp })
-    }
-
-    if (
-      sanitized.StripePromotionCodesEnabled !==
-      initial.StripePromotionCodesEnabled
-    ) {
-      updates.push({
-        key: 'StripePromotionCodesEnabled',
-        value: sanitized.StripePromotionCodesEnabled,
-      })
-    }
-
-    for (const update of updates) {
-      await updateOption.mutateAsync(update)
-    }
+  const currentFormValues = form.watch()
+  const waffoValues: WaffoSettingsValues = {
+    WaffoEnabled: currentFormValues.WaffoEnabled,
+    WaffoApiKey: currentFormValues.WaffoApiKey,
+    WaffoPrivateKey: currentFormValues.WaffoPrivateKey,
+    WaffoPublicCert: currentFormValues.WaffoPublicCert,
+    WaffoSandboxPublicCert: currentFormValues.WaffoSandboxPublicCert,
+    WaffoSandboxApiKey: currentFormValues.WaffoSandboxApiKey,
+    WaffoSandboxPrivateKey: currentFormValues.WaffoSandboxPrivateKey,
+    WaffoSandbox: currentFormValues.WaffoSandbox,
+    WaffoMerchantId: currentFormValues.WaffoMerchantId,
+    WaffoCurrency: currentFormValues.WaffoCurrency,
+    WaffoUnitPrice: currentFormValues.WaffoUnitPrice,
+    WaffoMinTopUp: currentFormValues.WaffoMinTopUp,
+    WaffoNotifyUrl: currentFormValues.WaffoNotifyUrl,
+    WaffoReturnUrl: currentFormValues.WaffoReturnUrl,
+    WaffoPayMethods: JSON.stringify(waffoPayMethods),
+  }
+  const waffoPancakeValues: WaffoPancakeSettingsValues = {
+    WaffoPancakeMerchantID: currentFormValues.WaffoPancakeMerchantID,
+    WaffoPancakePrivateKey: currentFormValues.WaffoPancakePrivateKey,
+    WaffoPancakeReturnURL: currentFormValues.WaffoPancakeReturnURL,
   }
 
   return (
-    <SettingsSection
-      title={t('Payment Gateway')}
-      description={t(
-        'Configure recharge pricing and payment gateway integrations'
-      )}
-    >
+    <SettingsSection title={t('Payment Gateway')}>
       {!complianceConfirmed ? (
         <Alert variant='destructive' className='mb-6'>
           <ShieldAlert className='h-4 w-4' />
@@ -747,782 +935,779 @@ export function PaymentSettingsSection({
         onConfirm={() => confirmComplianceMutation.mutate()}
       />
 
-      {/* eslint-disable react-hooks/refs */}
       <Form {...form}>
-        <form
+        <SettingsForm
           onSubmit={form.handleSubmit(onSubmit)}
           className={cn(
-            'space-y-8',
+            'gap-y-8',
             !complianceConfirmed && 'pointer-events-none opacity-40'
           )}
           data-no-autosubmit='true'
         >
-          <div className='space-y-4'>
-            <div>
-              <h3 className='text-lg font-medium'>{t('General Settings')}</h3>
-              <p className='text-muted-foreground text-sm'>
-                {t('Shared configuration for all payment gateways')}
-              </p>
+          <SettingsPageFormActions
+            onSave={form.handleSubmit(onSubmit)}
+            isSaving={updateOption.isPending || isSubmitting}
+            saveLabel='Save all settings'
+          />
+          <Tabs defaultValue='general' className='min-w-0'>
+            <div className='overflow-x-auto pb-1'>
+              <TabsList className='grid min-w-[44rem] grid-cols-9'>
+                <TabsTrigger value='general'>{t('General')}</TabsTrigger>
+                <TabsTrigger value='epay'>Epay</TabsTrigger>
+                <TabsTrigger value='stripe'>{t('Stripe')}</TabsTrigger>
+                <TabsTrigger value='creem'>Creem</TabsTrigger>
+                <TabsTrigger value='waffo-pancake'>Waffo Pancake</TabsTrigger>
+                <TabsTrigger value='waffo'>Waffo</TabsTrigger>
+                <TabsTrigger value='alipay'>{t('Alipay')}</TabsTrigger>
+                <TabsTrigger value='wxpay'>{t('WeChat Pay')}</TabsTrigger>
+                <TabsTrigger value='paypal'>PayPal</TabsTrigger>
+              </TabsList>
             </div>
 
-            <div className='grid gap-6 md:grid-cols-2'>
-              <FormField
-                control={form.control}
-                name='Price'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{t('Price (local currency / USD)')}</FormLabel>
-                    <FormControl>
-                      <Input
-                        type='number'
-                        step='0.01'
-                        min={0}
-                        value={(field.value ?? 0) as number}
-                        onChange={(event) =>
-                          field.onChange(event.target.valueAsNumber)
-                        }
-                      />
-                    </FormControl>
-                    <FormDescription>
-                      {t(
-                        'How much to charge for each US dollar of balance (Epay)'
-                      )}
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+            <TabsContent value='general' className={paymentTabContentClassName}>
+              <div className='space-y-4'>
+                <div>
+                  <h3 className='text-lg font-medium'>
+                    {t('General Settings')}
+                  </h3>
+                  <p className='text-muted-foreground text-sm'>
+                    {t('Shared configuration for all payment gateways')}
+                  </p>
+                </div>
 
-              <FormField
-                control={form.control}
-                name='MinTopUp'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{t('Minimum top-up (USD)')}</FormLabel>
-                    <FormControl>
-                      <Input
-                        type='number'
-                        step='0.01'
-                        min={0}
-                        value={(field.value ?? 0) as number}
-                        onChange={(event) =>
-                          field.onChange(event.target.valueAsNumber)
-                        }
-                      />
-                    </FormControl>
-                    <FormDescription>
-                      {t('Smallest USD amount users can recharge (Epay)')}
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-
-            <FormField
-              control={form.control}
-              name='PayMethods'
-              render={({ field }) => (
-                <FormItem>
-                  <div className='mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between'>
-                    <FormLabel>{t('Payment methods')}</FormLabel>
-                    <Button
-                      type='button'
-                      variant='outline'
-                      size='sm'
-                      onClick={() =>
-                        setPayMethodsVisualMode(!payMethodsVisualMode)
-                      }
-                      className='w-full sm:w-auto'
-                    >
-                      {payMethodsVisualMode ? (
-                        <>
-                          <Code2 className='mr-2 h-3 w-3' />
-                          {t('JSON Editor')}
-                        </>
-                      ) : (
-                        <>
-                          <Eye className='mr-2 h-3 w-3' />
-                          {t('Visual Editor')}
-                        </>
-                      )}
-                    </Button>
-                  </div>
-                  <FormControl>
-                    {payMethodsVisualMode ? (
-                      <PaymentMethodsVisualEditor
-                        value={field.value}
-                        onChange={field.onChange}
-                      />
-                    ) : (
-                      <Textarea
-                        rows={4}
-                        placeholder={t(
-                          '[{"name":"支付宝","type":"alipay","color":"#1677FF"}]'
-                        )}
-                        {...field}
-                        onChange={(event) => field.onChange(event.target.value)}
-                      />
+                <div className='grid gap-6 md:grid-cols-2'>
+                  <FormField
+                    control={form.control}
+                    name='Price'
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>
+                          {t('Price (local currency / USD)')}
+                        </FormLabel>
+                        <FormControl>
+                          <Input
+                            type='number'
+                            step='0.01'
+                            min={0}
+                            {...safeNumberFieldProps(field)}
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          {t(
+                            'How much to charge for each US dollar of balance (Epay)'
+                          )}
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
                     )}
-                  </FormControl>
-                  <FormDescription>
-                    {t(
-                      'Configure available payment methods. Provide a JSON array.'
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name='MinTopUp'
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t('Minimum top-up (USD)')}</FormLabel>
+                        <FormControl>
+                          <Input
+                            type='number'
+                            step='0.01'
+                            min={0}
+                            {...safeNumberFieldProps(field)}
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          {t('Smallest USD amount users can recharge (Epay)')}
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
                     )}
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+                  />
+                </div>
 
-            <div className='grid gap-6 md:grid-cols-2 md:items-start'>
-              <FormField
-                control={form.control}
-                name='AmountOptions'
-                render={({ field }) => (
-                  <FormItem>
-                    <div className='mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between'>
-                      <FormLabel>{t('Top-up amount options')}</FormLabel>
-                      <Button
-                        type='button'
-                        variant='outline'
-                        size='sm'
-                        onClick={() =>
-                          setAmountOptionsVisualMode(!amountOptionsVisualMode)
-                        }
-                        className='w-full sm:w-auto'
-                      >
-                        {amountOptionsVisualMode ? (
-                          <>
-                            <Code2 className='mr-2 h-3 w-3' />
-                            {t('JSON Editor')}
-                          </>
-                        ) : (
-                          <>
-                            <Eye className='mr-2 h-3 w-3' />
-                            {t('Visual Editor')}
-                          </>
-                        )}
-                      </Button>
-                    </div>
-                    <FormControl>
-                      {amountOptionsVisualMode ? (
-                        <AmountOptionsVisualEditor
-                          value={field.value}
-                          onChange={field.onChange}
-                        />
-                      ) : (
-                        <Textarea
-                          rows={4}
-                          placeholder='[10, 20, 50, 100]'
-                          {...field}
-                          onChange={(event) =>
-                            field.onChange(event.target.value)
+                <FormField
+                  control={form.control}
+                  name='PayMethods'
+                  render={({ field }) => (
+                    <FormItem>
+                      <div className='mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between'>
+                        <FormLabel>{t('Payment methods')}</FormLabel>
+                        <Button
+                          type='button'
+                          variant='outline'
+                          size='sm'
+                          onClick={() =>
+                            setPayMethodsVisualMode(!payMethodsVisualMode)
                           }
-                        />
-                      )}
-                    </FormControl>
-                    <FormDescription>
-                      {t('Preset recharge amounts (JSON array)')}
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name='AmountDiscount'
-                render={({ field }) => (
-                  <FormItem>
-                    <div className='mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between'>
-                      <FormLabel>{t('Amount discount')}</FormLabel>
-                      <Button
-                        type='button'
-                        variant='outline'
-                        size='sm'
-                        onClick={() =>
-                          setAmountDiscountVisualMode(!amountDiscountVisualMode)
-                        }
-                        className='w-full sm:w-auto'
-                      >
-                        {amountDiscountVisualMode ? (
-                          <>
-                            <Code2 className='mr-2 h-3 w-3' />
-                            {t('JSON Editor')}
-                          </>
+                          className='w-full sm:w-auto'
+                        >
+                          {payMethodsVisualMode ? (
+                            <>
+                              <Code2 className='mr-2 h-3 w-3' />
+                              {t('JSON Editor')}
+                            </>
+                          ) : (
+                            <>
+                              <Eye className='mr-2 h-3 w-3' />
+                              {t('Visual Editor')}
+                            </>
+                          )}
+                        </Button>
+                      </div>
+                      <FormControl>
+                        {payMethodsVisualMode ? (
+                          <PaymentMethodsVisualEditor
+                            value={field.value}
+                            onChange={field.onChange}
+                          />
                         ) : (
-                          <>
-                            <Eye className='mr-2 h-3 w-3' />
-                            {t('Visual Editor')}
-                          </>
+                          <Textarea
+                            rows={4}
+                            placeholder={t(
+                              '[{"name":"支付宝","type":"alipay","icon":"SiAlipay"}]'
+                            )}
+                            {...field}
+                            onChange={(event) =>
+                              field.onChange(event.target.value)
+                            }
+                          />
                         )}
-                      </Button>
-                    </div>
-                    <FormControl>
-                      {amountDiscountVisualMode ? (
-                        <AmountDiscountVisualEditor
-                          value={field.value}
-                          onChange={field.onChange}
-                        />
-                      ) : (
-                        <Textarea
-                          rows={4}
-                          placeholder='{"100":0.95,"200":0.9}'
-                          {...field}
-                          onChange={(event) =>
-                            field.onChange(event.target.value)
-                          }
-                        />
-                      )}
-                    </FormControl>
-                    <FormDescription>
-                      {t('Discount map by recharge amount (JSON object)')}
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-
-            <Button
-              type='button'
-              onClick={(e) => {
-                e.preventDefault()
-                e.stopPropagation()
-                saveGeneralSettings()
-              }}
-              disabled={updateOption.isPending}
-            >
-              {updateOption.isPending
-                ? t('Saving...')
-                : t('Save general settings')}
-            </Button>
-          </div>
-
-          <Separator />
-
-          <div className='space-y-4'>
-            <div>
-              <h3 className='text-lg font-medium'>{t('Epay Gateway')}</h3>
-              <p className='text-muted-foreground text-sm'>
-                {t('Configuration for Epay payment integration')}
-              </p>
-            </div>
-
-            <div className='grid gap-6 md:grid-cols-2'>
-              <FormField
-                control={form.control}
-                name='PayAddress'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{t('Epay endpoint')}</FormLabel>
-                    <FormControl>
-                      <Input
-                        placeholder={t('https://pay.example.com')}
-                        {...field}
-                        onChange={(event) => field.onChange(event.target.value)}
-                      />
-                    </FormControl>
-                    <FormDescription>
-                      {t('Base address provided by your Epay service')}
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name='CustomCallbackAddress'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{t('Callback address')}</FormLabel>
-                    <FormControl>
-                      <Input
-                        placeholder={t('https://gateway.example.com')}
-                        {...field}
-                        onChange={(event) => field.onChange(event.target.value)}
-                      />
-                    </FormControl>
-                    <FormDescription>
-                      {t(
-                        'Optional callback override. Leave blank to use server address'
-                      )}
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-
-            <div className='grid gap-6 md:grid-cols-2'>
-              <FormField
-                control={form.control}
-                name='EpayId'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{t('Epay merchant ID')}</FormLabel>
-                    <FormControl>
-                      <Input
-                        placeholder='10001'
-                        autoComplete='off'
-                        {...field}
-                        onChange={(event) => field.onChange(event.target.value)}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name='EpayKey'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{t('Epay secret key')}</FormLabel>
-                    <FormControl>
-                      <Input
-                        type='password'
-                        placeholder={t('Enter new key to update')}
-                        autoComplete='new-password'
-                        {...field}
-                        onChange={(event) => field.onChange(event.target.value)}
-                      />
-                    </FormControl>
-                    <FormDescription>
-                      {t('Leave blank unless rotating the secret')}
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-
-            <Button
-              type='button'
-              onClick={(e) => {
-                e.preventDefault()
-                e.stopPropagation()
-                saveEpaySettings()
-              }}
-              disabled={updateOption.isPending}
-            >
-              {updateOption.isPending
-                ? t('Saving...')
-                : t('Save Epay settings')}
-            </Button>
-          </div>
-
-          <Separator />
-
-          <div className='space-y-4'>
-            <div>
-              <h3 className='text-lg font-medium'>{t('Stripe Gateway')}</h3>
-              <p className='text-muted-foreground text-sm'>
-                {t('Configuration for Stripe payment integration')}
-              </p>
-            </div>
-
-            <div className='rounded-md bg-blue-50 p-4 text-sm text-blue-900 dark:bg-blue-950 dark:text-blue-100'>
-              <p className='mb-2 font-medium'>{t('Webhook Configuration:')}</p>
-              <ul className='list-inside list-disc space-y-1'>
-                <li>
-                  {t('Webhook URL:')}{' '}
-                  <code className='rounded bg-blue-100 px-1 py-0.5 text-xs dark:bg-blue-900'>
-                    {'<ServerAddress>/api/stripe/webhook'}
-                  </code>
-                </li>
-                <li>
-                  {t('Required events:')}{' '}
-                  <code className='rounded bg-blue-100 px-1 py-0.5 text-xs dark:bg-blue-900'>
-                    {t('checkout.session.completed')}
-                  </code>{' '}
-                  {t('and')}{' '}
-                  <code className='rounded bg-blue-100 px-1 py-0.5 text-xs dark:bg-blue-900'>
-                    {t('checkout.session.expired')}
-                  </code>
-                </li>
-                <li>
-                  {t('Configure at:')}{' '}
-                  <a
-                    href='https://dashboard.stripe.com/developers'
-                    target='_blank'
-                    rel='noreferrer'
-                    className='underline hover:no-underline'
-                  >
-                    {t('Stripe Dashboard')}
-                  </a>
-                </li>
-              </ul>
-            </div>
-
-            <div className='grid gap-6 md:grid-cols-3'>
-              <FormField
-                control={form.control}
-                name='StripeApiSecret'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{t('API secret')}</FormLabel>
-                    <FormControl>
-                      <Input
-                        type='password'
-                        placeholder={t('sk_xxx or rk_xxx')}
-                        autoComplete='new-password'
-                        {...field}
-                        onChange={(event) => field.onChange(event.target.value)}
-                      />
-                    </FormControl>
-                    <FormDescription>
-                      {t('Stripe API key (leave blank unless updating)')}
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name='StripeWebhookSecret'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{t('Webhook secret')}</FormLabel>
-                    <FormControl>
-                      <Input
-                        type='password'
-                        placeholder={t('whsec_xxx')}
-                        autoComplete='new-password'
-                        {...field}
-                        onChange={(event) => field.onChange(event.target.value)}
-                      />
-                    </FormControl>
-                    <FormDescription>
-                      {t(
-                        'Webhook signing secret (leave blank unless updating)'
-                      )}
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name='StripePriceId'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{t('Price ID')}</FormLabel>
-                    <FormControl>
-                      <Input
-                        placeholder={t('price_xxx')}
-                        {...field}
-                        onChange={(event) => field.onChange(event.target.value)}
-                      />
-                    </FormControl>
-                    <FormDescription>
-                      {t('Stripe product price ID')}
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-
-            <div className='grid gap-6 md:grid-cols-3'>
-              <FormField
-                control={form.control}
-                name='StripeUnitPrice'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>
-                      {t('Unit price (local currency / USD)')}
-                    </FormLabel>
-                    <FormControl>
-                      <Input
-                        type='number'
-                        step='0.01'
-                        min={0}
-                        value={(field.value ?? 0) as number}
-                        onChange={(event) =>
-                          field.onChange(event.target.valueAsNumber)
-                        }
-                      />
-                    </FormControl>
-                    <FormDescription>
-                      {t('e.g., 8 means 8 local currency per USD')}
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name='StripeMinTopUp'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{t('Minimum top-up (USD)')}</FormLabel>
-                    <FormControl>
-                      <Input
-                        type='number'
-                        step='0.01'
-                        min={0}
-                        value={(field.value ?? 0) as number}
-                        onChange={(event) =>
-                          field.onChange(event.target.valueAsNumber)
-                        }
-                      />
-                    </FormControl>
-                    <FormDescription>
-                      {t('Minimum recharge amount in USD')}
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name='StripePromotionCodesEnabled'
-                render={({ field }) => (
-                  <FormItem className='flex flex-row items-center justify-between rounded-lg border p-4'>
-                    <div className='space-y-0.5'>
-                      <FormLabel className='text-base'>
-                        {t('Promotion codes')}
-                      </FormLabel>
+                      </FormControl>
                       <FormDescription>
-                        {t('Allow users to enter promo codes')}
+                        {t(
+                          'Configured as PayMethods JSON. The type value decides which payment flow is used: stripe for Stripe, waffo_pancake for Waffo Pancake, and other values are sent to Epay as the type parameter.'
+                        )}
                       </FormDescription>
-                    </div>
-                    <FormControl>
-                      <Switch
-                        checked={field.value}
-                        onCheckedChange={field.onChange}
-                      />
-                    </FormControl>
-                  </FormItem>
-                )}
-              />
-            </div>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
-            <Button
-              type='button'
-              onClick={(e) => {
-                e.preventDefault()
-                e.stopPropagation()
-                saveStripeSettings()
-              }}
-              disabled={updateOption.isPending}
-            >
-              {updateOption.isPending
-                ? t('Saving...')
-                : t('Save Stripe settings')}
-            </Button>
-          </div>
-
-          <Separator />
-
-          <div className='space-y-4'>
-            <div>
-              <h3 className='text-lg font-medium'>{t('Creem Gateway')}</h3>
-              <p className='text-muted-foreground text-sm'>
-                {t('Configuration for Creem payment integration')}
-              </p>
-            </div>
-
-            <div className='rounded-md bg-blue-50 p-4 text-sm text-blue-900 dark:bg-blue-950 dark:text-blue-100'>
-              <p className='mb-2 font-medium'>{t('Webhook Configuration:')}</p>
-              <ul className='list-inside list-disc space-y-1'>
-                <li>
-                  {t('Webhook URL:')}{' '}
-                  <code className='rounded bg-blue-100 px-1 py-0.5 text-xs dark:bg-blue-900'>
-                    {'<ServerAddress>/api/creem/webhook'}
-                  </code>
-                </li>
-                <li>{t('Configure in your Creem dashboard')}</li>
-              </ul>
-            </div>
-
-            <div className='grid gap-6 md:grid-cols-2'>
-              <FormField
-                control={form.control}
-                name='CreemApiKey'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{t('API Key')}</FormLabel>
-                    <FormControl>
-                      <Input
-                        type='password'
-                        placeholder={t('Enter Creem API key')}
-                        autoComplete='new-password'
-                        {...field}
-                        onChange={(event) => field.onChange(event.target.value)}
-                      />
-                    </FormControl>
-                    <FormDescription>
-                      {t('Creem API key (leave blank unless updating)')}
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name='CreemWebhookSecret'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{t('Webhook Secret')}</FormLabel>
-                    <FormControl>
-                      <Input
-                        type='password'
-                        placeholder={t('Enter webhook secret')}
-                        autoComplete='new-password'
-                        {...field}
-                        onChange={(event) => field.onChange(event.target.value)}
-                      />
-                    </FormControl>
-                    <FormDescription>
-                      {t(
-                        'Webhook signing secret (leave blank unless updating)'
-                      )}
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-
-            <FormField
-              control={form.control}
-              name='CreemTestMode'
-              render={({ field }) => (
-                <FormItem className='flex flex-row items-center justify-between rounded-lg border p-4'>
-                  <div className='space-y-0.5'>
-                    <FormLabel className='text-base'>
-                      {t('Test Mode')}
-                    </FormLabel>
-                    <FormDescription>
-                      {t('Enable test mode for Creem payments')}
-                    </FormDescription>
-                  </div>
-                  <FormControl>
-                    <Switch
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                    />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name='CreemProducts'
-              render={({ field }) => (
-                <FormItem>
-                  <div className='mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between'>
-                    <FormLabel>{t('Products')}</FormLabel>
-                    <Button
-                      type='button'
-                      variant='outline'
-                      size='sm'
-                      onClick={() =>
-                        setCreemProductsVisualMode(!creemProductsVisualMode)
-                      }
-                      className='w-full sm:w-auto'
-                    >
-                      {creemProductsVisualMode ? (
-                        <>
-                          <Code2 className='mr-2 h-3 w-3' />
-                          {t('JSON Editor')}
-                        </>
-                      ) : (
-                        <>
-                          <Eye className='mr-2 h-3 w-3' />
-                          {t('Visual Editor')}
-                        </>
-                      )}
-                    </Button>
-                  </div>
-                  <FormControl>
-                    {creemProductsVisualMode ? (
-                      <CreemProductsVisualEditor
-                        value={field.value}
-                        onChange={field.onChange}
-                      />
-                    ) : (
-                      <Textarea
-                        rows={4}
-                        placeholder='[{"name":"Basic","productId":"prod_xxx","price":10,"quota":500000,"currency":"USD"}]'
-                        {...field}
-                        onChange={(event) => field.onChange(event.target.value)}
-                      />
+                <div className='grid gap-6 md:grid-cols-2 md:items-start'>
+                  <FormField
+                    control={form.control}
+                    name='AmountOptions'
+                    render={({ field }) => (
+                      <FormItem>
+                        <div className='mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between'>
+                          <FormLabel>{t('Top-up amount options')}</FormLabel>
+                          <Button
+                            type='button'
+                            variant='outline'
+                            size='sm'
+                            onClick={() =>
+                              setAmountOptionsVisualMode(
+                                !amountOptionsVisualMode
+                              )
+                            }
+                            className='w-full sm:w-auto'
+                          >
+                            {amountOptionsVisualMode ? (
+                              <>
+                                <Code2 className='mr-2 h-3 w-3' />
+                                {t('JSON Editor')}
+                              </>
+                            ) : (
+                              <>
+                                <Eye className='mr-2 h-3 w-3' />
+                                {t('Visual Editor')}
+                              </>
+                            )}
+                          </Button>
+                        </div>
+                        <FormControl>
+                          {amountOptionsVisualMode ? (
+                            <AmountOptionsVisualEditor
+                              value={field.value}
+                              onChange={field.onChange}
+                            />
+                          ) : (
+                            <Textarea
+                              rows={4}
+                              placeholder='[10, 20, 50, 100]'
+                              {...field}
+                              onChange={(event) =>
+                                field.onChange(event.target.value)
+                              }
+                            />
+                          )}
+                        </FormControl>
+                        <FormDescription>
+                          {t('Preset recharge amounts (JSON array)')}
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
                     )}
-                  </FormControl>
-                  <FormDescription>
-                    {t('Configure Creem products. Provide a JSON array.')}
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+                  />
 
-            <Button
-              type='button'
-              onClick={(e) => {
-                e.preventDefault()
-                e.stopPropagation()
-                saveCreemSettings()
-              }}
-              disabled={updateOption.isPending}
+                  <FormField
+                    control={form.control}
+                    name='AmountDiscount'
+                    render={({ field }) => (
+                      <FormItem>
+                        <div className='mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between'>
+                          <FormLabel>{t('Amount discount')}</FormLabel>
+                          <Button
+                            type='button'
+                            variant='outline'
+                            size='sm'
+                            onClick={() =>
+                              setAmountDiscountVisualMode(
+                                !amountDiscountVisualMode
+                              )
+                            }
+                            className='w-full sm:w-auto'
+                          >
+                            {amountDiscountVisualMode ? (
+                              <>
+                                <Code2 className='mr-2 h-3 w-3' />
+                                {t('JSON Editor')}
+                              </>
+                            ) : (
+                              <>
+                                <Eye className='mr-2 h-3 w-3' />
+                                {t('Visual Editor')}
+                              </>
+                            )}
+                          </Button>
+                        </div>
+                        <FormControl>
+                          {amountDiscountVisualMode ? (
+                            <AmountDiscountVisualEditor
+                              value={field.value}
+                              onChange={field.onChange}
+                            />
+                          ) : (
+                            <Textarea
+                              rows={4}
+                              placeholder='{"100":0.95,"200":0.9}'
+                              {...field}
+                              onChange={(event) =>
+                                field.onChange(event.target.value)
+                              }
+                            />
+                          )}
+                        </FormControl>
+                        <FormDescription>
+                          {t('Discount map by recharge amount (JSON object)')}
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+              </div>
+            </TabsContent>
+
+            <TabsContent value='epay' className={paymentTabContentClassName}>
+              <div className='space-y-4'>
+                <div>
+                  <h3 className='text-lg font-medium'>{t('Epay Gateway')}</h3>
+                  <p className='text-muted-foreground text-sm'>
+                    {t('Configuration for Epay payment integration')}
+                  </p>
+                </div>
+
+                <Alert>
+                  <ShieldAlert className='h-4 w-4' />
+                  <AlertTitle>{t('Epay safety reminder')}</AlertTitle>
+                  <AlertDescription>
+                    {t(
+                      'Epay is a payment protocol, not a specific official website. Verify the provider yourself and do not trust random third-party Epay deployments.'
+                    )}
+                  </AlertDescription>
+                </Alert>
+
+                <div className='grid gap-6 md:grid-cols-2'>
+                  <FormField
+                    control={form.control}
+                    name='PayAddress'
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t('Epay endpoint')}</FormLabel>
+                        <FormControl>
+                          <Input
+                            placeholder={t('https://pay.example.com')}
+                            {...field}
+                            onChange={(event) =>
+                              field.onChange(event.target.value)
+                            }
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          {t('Base address provided by your Epay service')}
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name='CustomCallbackAddress'
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t('Callback address')}</FormLabel>
+                        <FormControl>
+                          <Input
+                            placeholder={t('https://gateway.example.com')}
+                            {...field}
+                            onChange={(event) =>
+                              field.onChange(event.target.value)
+                            }
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          {t(
+                            'Only enter the site origin, for example https://api.example.com. Do not include any path such as /api/user/epay/notify. Leave blank to use the server address.'
+                          )}
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                <div className='grid gap-6 md:grid-cols-2'>
+                  <FormField
+                    control={form.control}
+                    name='EpayId'
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t('Epay merchant ID')}</FormLabel>
+                        <FormControl>
+                          <Input
+                            placeholder='10001'
+                            autoComplete='off'
+                            {...field}
+                            onChange={(event) =>
+                              field.onChange(event.target.value)
+                            }
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name='EpayKey'
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t('Epay secret key')}</FormLabel>
+                        <FormControl>
+                          <Input
+                            type='password'
+                            placeholder={t('Enter new key to update')}
+                            autoComplete='new-password'
+                            {...field}
+                            onChange={(event) =>
+                              field.onChange(event.target.value)
+                            }
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          {t('Leave blank unless rotating the secret')}
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+              </div>
+            </TabsContent>
+
+            <TabsContent value='stripe' className={paymentTabContentClassName}>
+              <div className='space-y-4'>
+                <div>
+                  <h3 className='text-lg font-medium'>{t('Stripe Gateway')}</h3>
+                  <p className='text-muted-foreground text-sm'>
+                    {t('Configuration for Stripe payment integration')}
+                  </p>
+                </div>
+
+                <div className='rounded-md bg-blue-50 p-4 text-sm text-blue-900 dark:bg-blue-950 dark:text-blue-100'>
+                  <p className='mb-2 font-medium'>
+                    {t('Webhook Configuration:')}
+                  </p>
+                  <ul className='list-inside list-disc space-y-1'>
+                    <li>
+                      {t('Webhook URL:')}{' '}
+                      <code className='rounded bg-blue-100 px-1 py-0.5 text-xs dark:bg-blue-900'>
+                        {'<ServerAddress>/api/stripe/webhook'}
+                      </code>
+                    </li>
+                    <li>
+                      {t('Required events:')}{' '}
+                      <code className='rounded bg-blue-100 px-1 py-0.5 text-xs dark:bg-blue-900'>
+                        {t('checkout.session.completed')}
+                      </code>{' '}
+                      {t('and')}{' '}
+                      <code className='rounded bg-blue-100 px-1 py-0.5 text-xs dark:bg-blue-900'>
+                        {t('checkout.session.expired')}
+                      </code>
+                    </li>
+                    <li>
+                      {t('Configure at:')}{' '}
+                      <a
+                        href='https://dashboard.stripe.com/developers'
+                        target='_blank'
+                        rel='noreferrer'
+                        className='underline hover:no-underline'
+                      >
+                        {t('Stripe Dashboard')}
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+
+                <div className='grid gap-6 md:grid-cols-3'>
+                  <FormField
+                    control={form.control}
+                    name='StripeApiSecret'
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t('API secret')}</FormLabel>
+                        <FormControl>
+                          <Input
+                            type='password'
+                            placeholder={t('sk_xxx or rk_xxx')}
+                            autoComplete='new-password'
+                            {...field}
+                            onChange={(event) =>
+                              field.onChange(event.target.value)
+                            }
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          {t('Stripe API key (leave blank unless updating)')}
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name='StripeWebhookSecret'
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t('Webhook secret')}</FormLabel>
+                        <FormControl>
+                          <Input
+                            type='password'
+                            placeholder={t('whsec_xxx')}
+                            autoComplete='new-password'
+                            {...field}
+                            onChange={(event) =>
+                              field.onChange(event.target.value)
+                            }
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          {t(
+                            'Webhook signing secret (leave blank unless updating)'
+                          )}
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name='StripePriceId'
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t('Price ID')}</FormLabel>
+                        <FormControl>
+                          <Input
+                            placeholder={t('price_xxx')}
+                            {...field}
+                            onChange={(event) =>
+                              field.onChange(event.target.value)
+                            }
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          {t('Stripe product price ID')}
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                <div className='grid gap-6 md:grid-cols-3'>
+                  <FormField
+                    control={form.control}
+                    name='StripeUnitPrice'
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>
+                          {t('Unit price (local currency / USD)')}
+                        </FormLabel>
+                        <FormControl>
+                          <Input
+                            type='number'
+                            step='0.01'
+                            min={0}
+                            {...safeNumberFieldProps(field)}
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          {t('e.g., 8 means 8 local currency per USD')}
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name='StripeMinTopUp'
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t('Minimum top-up (USD)')}</FormLabel>
+                        <FormControl>
+                          <Input
+                            type='number'
+                            step='0.01'
+                            min={0}
+                            {...safeNumberFieldProps(field)}
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          {t('Minimum recharge amount in USD')}
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name='StripePromotionCodesEnabled'
+                    render={({ field }) => (
+                      <SettingsSwitchItem>
+                        <SettingsSwitchContent>
+                          <FormLabel>{t('Promotion codes')}</FormLabel>
+                          <FormDescription>
+                            {t('Allow users to enter promo codes')}
+                          </FormDescription>
+                        </SettingsSwitchContent>
+                        <FormControl>
+                          <Switch
+                            checked={field.value}
+                            onCheckedChange={field.onChange}
+                          />
+                        </FormControl>
+                      </SettingsSwitchItem>
+                    )}
+                  />
+                </div>
+              </div>
+            </TabsContent>
+
+            <TabsContent value='creem' className={paymentTabContentClassName}>
+              <div className='space-y-4'>
+                <div>
+                  <h3 className='text-lg font-medium'>{t('Creem Gateway')}</h3>
+                  <p className='text-muted-foreground text-sm'>
+                    {t('Configuration for Creem payment integration')}
+                  </p>
+                </div>
+
+                <div className='rounded-md bg-blue-50 p-4 text-sm text-blue-900 dark:bg-blue-950 dark:text-blue-100'>
+                  <p className='mb-2 font-medium'>
+                    {t('Webhook Configuration:')}
+                  </p>
+                  <ul className='list-inside list-disc space-y-1'>
+                    <li>
+                      {t('Webhook URL:')}{' '}
+                      <code className='rounded bg-blue-100 px-1 py-0.5 text-xs dark:bg-blue-900'>
+                        {'<ServerAddress>/api/creem/webhook'}
+                      </code>
+                    </li>
+                    <li>{t('Configure in your Creem dashboard')}</li>
+                  </ul>
+                </div>
+
+                <div className='grid gap-6 md:grid-cols-2'>
+                  <FormField
+                    control={form.control}
+                    name='CreemApiKey'
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t('API Key')}</FormLabel>
+                        <FormControl>
+                          <Input
+                            type='password'
+                            placeholder={t('Enter Creem API key')}
+                            autoComplete='new-password'
+                            {...field}
+                            onChange={(event) =>
+                              field.onChange(event.target.value)
+                            }
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          {t('Creem API key (leave blank unless updating)')}
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name='CreemWebhookSecret'
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t('Webhook Secret')}</FormLabel>
+                        <FormControl>
+                          <Input
+                            type='password'
+                            placeholder={t('Enter webhook secret')}
+                            autoComplete='new-password'
+                            {...field}
+                            onChange={(event) =>
+                              field.onChange(event.target.value)
+                            }
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          {t(
+                            'Webhook signing secret (leave blank unless updating)'
+                          )}
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                <FormField
+                  control={form.control}
+                  name='CreemTestMode'
+                  render={({ field }) => (
+                    <SettingsSwitchItem>
+                      <SettingsSwitchContent>
+                        <FormLabel>{t('Test Mode')}</FormLabel>
+                        <FormDescription>
+                          {t('Enable test mode for Creem payments')}
+                        </FormDescription>
+                      </SettingsSwitchContent>
+                      <FormControl>
+                        <Switch
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                        />
+                      </FormControl>
+                    </SettingsSwitchItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name='CreemProducts'
+                  render={({ field }) => (
+                    <FormItem>
+                      <div className='mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between'>
+                        <FormLabel>{t('Products')}</FormLabel>
+                        <Button
+                          type='button'
+                          variant='outline'
+                          size='sm'
+                          onClick={() =>
+                            setCreemProductsVisualMode(!creemProductsVisualMode)
+                          }
+                          className='w-full sm:w-auto'
+                        >
+                          {creemProductsVisualMode ? (
+                            <>
+                              <Code2 className='mr-2 h-3 w-3' />
+                              {t('JSON Editor')}
+                            </>
+                          ) : (
+                            <>
+                              <Eye className='mr-2 h-3 w-3' />
+                              {t('Visual Editor')}
+                            </>
+                          )}
+                        </Button>
+                      </div>
+                      <FormControl>
+                        {creemProductsVisualMode ? (
+                          <CreemProductsVisualEditor
+                            value={field.value}
+                            onChange={field.onChange}
+                          />
+                        ) : (
+                          <Textarea
+                            rows={4}
+                            placeholder='[{"name":"Basic","productId":"prod_xxx","price":10,"quota":500000,"currency":"USD"}]'
+                            {...field}
+                            onChange={(event) =>
+                              field.onChange(event.target.value)
+                            }
+                          />
+                        )}
+                      </FormControl>
+                      <FormDescription>
+                        {t('Configure Creem products. Provide a JSON array.')}
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </TabsContent>
+
+            <TabsContent
+              value='waffo-pancake'
+              className={paymentTabContentClassName}
             >
-              {updateOption.isPending
-                ? t('Saving...')
-                : t('Save Creem settings')}
-            </Button>
-          </div>
+              <WaffoPancakeSettingsSection
+                defaultValues={waffoPancakeDefaultValues}
+                values={waffoPancakeValues}
+                onValueChange={setWaffoPancakeValue}
+                selectedBinding={waffoPancakeSelection}
+                savedBinding={waffoPancakeSavedBinding}
+                onSelectedBindingChange={setWaffoPancakeSelection}
+              />
+            </TabsContent>
 
-          <Button type='submit' disabled={updateOption.isPending}>
-            {updateOption.isPending ? t('Saving...') : t('Save all settings')}
-          </Button>
-        </form>
+            <TabsContent value='waffo' className={paymentTabContentClassName}>
+              <WaffoSettingsSection
+                values={waffoValues}
+                onValueChange={setWaffoValue}
+                payMethods={waffoPayMethods}
+                onPayMethodsChange={setWaffoPayMethods}
+              />
+            </TabsContent>
+
+            <TabsContent value='alipay' className={paymentTabContentClassName}>
+              <AlipaySettingsSection
+                form={form}
+                serverAddress={serverAddress}
+              />
+            </TabsContent>
+
+            <TabsContent value='wxpay' className={paymentTabContentClassName}>
+              <WxpaySettingsSection form={form} serverAddress={serverAddress} />
+            </TabsContent>
+
+            <TabsContent value='paypal' className={paymentTabContentClassName}>
+              <PayPalSettingsSection
+                form={form}
+                serverAddress={serverAddress}
+              />
+            </TabsContent>
+          </Tabs>
+        </SettingsForm>
       </Form>
-
-      <Separator />
-
-      <WaffoPancakeSettingsSection
-        defaultValues={waffoPancakeDefaultValues}
-        provisionedStoreID={waffoPancakeProvisionedStoreID}
-        provisionedProductID={waffoPancakeProvisionedProductID}
-      />
-
-      <Separator />
-
-      <WaffoSettingsSection defaultValues={waffoDefaultValues} />
-
-      <Separator />
-
-      <PayPalSettingsSection
-        defaultValues={paypalDefaultValues}
-        serverAddress={serverAddress}
-      />
-
-      <Separator />
-
-      <AlipaySettingsSection
-        defaultValues={alipayDefaultValues}
-        serverAddress={serverAddress}
-      />
-
-      <Separator />
-
-      <WxpaySettingsSection
-        defaultValues={wxpayDefaultValues}
-        serverAddress={serverAddress}
-      />
-      {/* eslint-enable react-hooks/refs */}
     </SettingsSection>
   )
 }

--- a/web/default/src/features/system-settings/integrations/paypal-settings-section.tsx
+++ b/web/default/src/features/system-settings/integrations/paypal-settings-section.tsx
@@ -16,8 +16,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { useEffect, useState } from 'react'
-import { useForm } from 'react-hook-form'
+import { useState } from 'react'
+import type { UseFormReturn } from 'react-hook-form'
 import { useQueryClient } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -41,6 +41,7 @@ import {
 import { SettingsSection } from '../components/settings-section'
 import { useUpdateOption } from '../hooks/use-update-option'
 import { buildDisablePayPalOptions } from './paypal-options'
+import type { PaymentFormValues } from './payment-settings-section'
 
 /**
  * Heuristic to detect a masked secret returned from the server.
@@ -62,80 +63,59 @@ export interface PayPalSettingsValues {
 }
 
 interface Props {
-  defaultValues: PayPalSettingsValues
+  form: UseFormReturn<PaymentFormValues>
   serverAddress?: string
 }
 
-export function PayPalSettingsSection({ defaultValues, serverAddress }: Props) {
+type PayPalUpdate = { key: string; value: string }
+
+/**
+ * Build option updates for PayPal using the same mask/changed guards as the
+ * original self-contained save. PayPal has no Enabled switch; Mode and MinTopUp
+ * are always written (matching prior behavior).
+ */
+export function buildPayPalUpdates(values: PayPalSettingsValues): {
+  options: PayPalUpdate[]
+} {
+  const options: PayPalUpdate[] = []
+
+  // ClientId — only push if not masked (sensitive field)
+  if (values.PayPalClientId && !isMaskedSecret(values.PayPalClientId)) {
+    options.push({ key: 'PayPalClientId', value: values.PayPalClientId })
+  }
+
+  // Only push sensitive fields if they were actually edited
+  // (i.e., not still masked from the server response)
+  if (values.PayPalClientSecret && !isMaskedSecret(values.PayPalClientSecret)) {
+    options.push({
+      key: 'PayPalClientSecret',
+      value: values.PayPalClientSecret,
+    })
+  }
+  if (
+    values.PayPalWebhookSecret &&
+    !isMaskedSecret(values.PayPalWebhookSecret)
+  ) {
+    options.push({
+      key: 'PayPalWebhookSecret',
+      value: values.PayPalWebhookSecret,
+    })
+  }
+
+  options.push({ key: 'PayPalMode', value: values.PayPalMode || 'sandbox' })
+  options.push({
+    key: 'PayPalMinTopUp',
+    value: String(values.PayPalMinTopUp || 1),
+  })
+
+  return { options }
+}
+
+export function PayPalSettingsSection({ form, serverAddress }: Props) {
   const { t } = useTranslation()
   const updateOption = useUpdateOption()
   const queryClient = useQueryClient()
   const [loading, setLoading] = useState(false)
-
-  const form = useForm<PayPalSettingsValues>({
-    defaultValues,
-  })
-
-  useEffect(() => {
-    form.reset(defaultValues)
-  }, [defaultValues, form])
-
-  const handleSave = async () => {
-    setLoading(true)
-    try {
-      const values = form.getValues()
-      const options: { key: string; value: string }[] = []
-
-      // ClientId — only push if not masked (sensitive field)
-      if (values.PayPalClientId && !isMaskedSecret(values.PayPalClientId)) {
-        options.push({ key: 'PayPalClientId', value: values.PayPalClientId })
-      }
-
-      // Only push sensitive fields if they were actually edited
-      // (i.e., not still masked from the server response)
-      if (
-        values.PayPalClientSecret &&
-        !isMaskedSecret(values.PayPalClientSecret)
-      ) {
-        options.push({
-          key: 'PayPalClientSecret',
-          value: values.PayPalClientSecret,
-        })
-      }
-      if (
-        values.PayPalWebhookSecret &&
-        !isMaskedSecret(values.PayPalWebhookSecret)
-      ) {
-        options.push({
-          key: 'PayPalWebhookSecret',
-          value: values.PayPalWebhookSecret,
-        })
-      }
-
-      options.push({
-        key: 'PayPalMode',
-        value: values.PayPalMode || 'sandbox',
-      })
-      options.push({
-        key: 'PayPalMinTopUp',
-        value: String(values.PayPalMinTopUp || 1),
-      })
-
-      for (const opt of options) {
-        await updateOption.mutateAsync(opt)
-      }
-      // Re-fetch options from the API. The backend strips sensitive fields
-      // (suffix Secret/Key/Token), so the refreshed defaultValues will have
-      // those fields as empty — non-sensitive fields like PayPalMode and
-      // PayPalMinTopUp will be re-populated with their saved values.
-      await queryClient.invalidateQueries({ queryKey: ['system-options'] })
-      toast.success(t('Updated successfully'))
-    } catch {
-      toast.error(t('Update failed'))
-    } finally {
-      setLoading(false)
-    }
-  }
 
   const handleDisable = async () => {
     setLoading(true)
@@ -143,12 +123,9 @@ export function PayPalSettingsSection({ defaultValues, serverAddress }: Props) {
       for (const opt of buildDisablePayPalOptions()) {
         await updateOption.mutateAsync(opt)
       }
-      form.reset({
-        ...form.getValues(),
-        PayPalClientId: '',
-        PayPalClientSecret: '',
-        PayPalWebhookSecret: '',
-      })
+      form.setValue('PayPalClientId', '')
+      form.setValue('PayPalClientSecret', '')
+      form.setValue('PayPalWebhookSecret', '')
       await queryClient.invalidateQueries({ queryKey: ['system-options'] })
       toast.success(t('PayPal disabled'))
     } catch {
@@ -163,12 +140,12 @@ export function PayPalSettingsSection({ defaultValues, serverAddress }: Props) {
     : '<ServerAddress>/api/paypal/webhook'
 
   return (
-    <SettingsSection
-      title={t('PayPal Settings')}
-      description={t('Configure PayPal payment gateway for top-ups')}
-    >
+    <SettingsSection title={t('PayPal Settings')}>
+      <p className='text-muted-foreground text-sm'>
+        {t('Configure PayPal payment gateway for top-ups')}
+      </p>
       <Form {...form}>
-        <form className='space-y-4'>
+        <div className='space-y-4'>
           <div className='rounded-md bg-blue-50 p-4 text-sm text-blue-900 dark:bg-blue-950 dark:text-blue-100'>
             <p className='mb-2 font-medium'>
               {t('PayPal Webhook Configuration:')}
@@ -331,9 +308,6 @@ export function PayPalSettingsSection({ defaultValues, serverAddress }: Props) {
           />
 
           <div className='flex flex-wrap gap-2'>
-            <Button type='button' onClick={handleSave} disabled={loading}>
-              {loading ? t('Saving...') : t('Save PayPal settings')}
-            </Button>
             <Button
               type='button'
               variant='outline'
@@ -343,7 +317,7 @@ export function PayPalSettingsSection({ defaultValues, serverAddress }: Props) {
               {t('Disable PayPal')}
             </Button>
           </div>
-        </form>
+        </div>
       </Form>
     </SettingsSection>
   )

--- a/web/default/src/features/system-settings/integrations/waffo-pancake-settings-section.tsx
+++ b/web/default/src/features/system-settings/integrations/waffo-pancake-settings-section.tsx
@@ -17,20 +17,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 For commercial licensing, please contact support@quantumnous.com
 */
 import * as React from 'react'
-import * as z from 'zod'
-import { useForm } from 'react-hook-form'
-import { zodResolver } from '@hookform/resolvers/zod'
+import type { SetStateAction } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import {
@@ -48,23 +38,29 @@ import {
   type PairResult,
   createWaffoPancakePair,
   listWaffoPancakeCatalog,
-  saveWaffoPancakeConfig,
 } from './waffo-pancake-api'
 
-// Only operator-typed fields. Nothing else lands in OptionMap until Save.
-const waffoPancakeSchema = z.object({
-  WaffoPancakeMerchantID: z.string(),
-  WaffoPancakePrivateKey: z.string(),
-})
-
-export type WaffoPancakeSettingsValues = z.infer<typeof waffoPancakeSchema> & {
+export type WaffoPancakeSettingsValues = {
+  WaffoPancakeMerchantID: string
+  WaffoPancakePrivateKey: string
   WaffoPancakeReturnURL: string
+}
+
+export interface WaffoPancakeBinding {
+  storeID: string
+  productID: string
 }
 
 interface Props {
   defaultValues: WaffoPancakeSettingsValues
-  provisionedStoreID?: string
-  provisionedProductID?: string
+  values: WaffoPancakeSettingsValues
+  onValueChange: <K extends keyof WaffoPancakeSettingsValues>(
+    key: K,
+    value: WaffoPancakeSettingsValues[K]
+  ) => void
+  selectedBinding: WaffoPancakeBinding
+  savedBinding: WaffoPancakeBinding
+  onSelectedBindingChange: (value: SetStateAction<WaffoPancakeBinding>) => void
 }
 
 const PANCAKE_DASHBOARD_URL = 'https://pancake.waffo.ai/merchant/dashboard'
@@ -72,50 +68,35 @@ const DEFAULT_NEW_STORE_NAME = 'new-api-store'
 const DEFAULT_NEW_PRODUCT_NAME = 'new-api-charge-product'
 const DEFAULT_NEW_PAIR_NAME = `${DEFAULT_NEW_STORE_NAME} + ${DEFAULT_NEW_PRODUCT_NAME}`
 
-export function WaffoPancakeSettingsSection(props: Props) {
+export function WaffoPancakeSettingsSection({
+  defaultValues,
+  values,
+  onValueChange,
+  selectedBinding,
+  savedBinding,
+  onSelectedBindingChange,
+}: Props) {
   const { t } = useTranslation()
 
-  const [storeID, setStoreID] = React.useState(props.provisionedStoreID ?? '')
-  const [productID, setProductID] = React.useState(
-    props.provisionedProductID ?? ''
-  )
-
-  const [phase, setPhase] = React.useState<'idle' | 'verifying' | 'saving'>(
-    'idle'
-  )
+  const [phase, setPhase] = React.useState<'idle' | 'verifying'>('idle')
   const [catalog, setCatalog] = React.useState<CatalogStore[]>([])
-  // Seed dropdowns from saved bindings so they render on first paint instead
-  // of waiting for the async catalog fetch to confirm them.
-  const [chosenStoreID, setChosenStoreID] = React.useState<string>(
-    props.provisionedStoreID ?? ''
-  )
-  const [chosenProductID, setChosenProductID] = React.useState<string>(
-    props.provisionedProductID ?? ''
-  )
-  const [returnURL, setReturnURL] = React.useState(
-    props.defaultValues.WaffoPancakeReturnURL ?? ''
-  )
   const [creatingPair, setCreatingPair] = React.useState(false)
+  const chosenStoreID = selectedBinding.storeID
+  const chosenProductID = selectedBinding.productID
+  const storeID = savedBinding.storeID
+  const productID = savedBinding.productID
+  const returnURL = values.WaffoPancakeReturnURL
 
-  const initialRef = React.useRef(props.defaultValues)
+  const initialRef = React.useRef(defaultValues)
   const defaultsSignature = React.useMemo(
-    () => JSON.stringify(props.defaultValues),
-    [props.defaultValues]
+    () => JSON.stringify(defaultValues),
+    [defaultValues]
   )
 
   // "merchantID|privateKey" of the last verified pair; debounced verify
   // skips when nothing changed.
   const lastVerifiedSignature = React.useRef('')
   const fetchSerialRef = React.useRef(0)
-
-  const form = useForm({
-    resolver: zodResolver(waffoPancakeSchema),
-    mode: 'onChange',
-    defaultValues: {
-      WaffoPancakeMerchantID: props.defaultValues.WaffoPancakeMerchantID,
-      WaffoPancakePrivateKey: props.defaultValues.WaffoPancakePrivateKey,
-    },
-  })
 
   // Mount-only — never re-sync from props after the first render. The
   // backend strips PrivateKey from GET /api/option/, so a re-sync would
@@ -126,21 +107,8 @@ export function WaffoPancakeSettingsSection(props: Props) {
     initialRef.current = parsed
     if (didMountRef.current) return
     didMountRef.current = true
-    form.reset({
-      WaffoPancakeMerchantID: parsed.WaffoPancakeMerchantID,
-      WaffoPancakePrivateKey: parsed.WaffoPancakePrivateKey,
-    })
-    setReturnURL(parsed.WaffoPancakeReturnURL ?? '')
     lastVerifiedSignature.current = `${parsed.WaffoPancakeMerchantID.trim()}|${parsed.WaffoPancakePrivateKey.trim()}`
-  }, [defaultsSignature, form])
-
-  React.useEffect(() => {
-    setStoreID(props.provisionedStoreID ?? '')
-  }, [props.provisionedStoreID])
-
-  React.useEffect(() => {
-    setProductID(props.provisionedProductID ?? '')
-  }, [props.provisionedProductID])
+  }, [defaultsSignature])
 
   const productsForChosenStore = React.useMemo(() => {
     if (!chosenStoreID) return []
@@ -183,7 +151,7 @@ export function WaffoPancakeSettingsSection(props: Props) {
       preselect?: { storeID?: string; productID?: string }
     ) => {
       const serial = ++fetchSerialRef.current
-      let stores: CatalogStore[] = []
+      let stores: CatalogStore[]
       try {
         const body = await listWaffoPancakeCatalog(merchantID, privateKey)
         if (serial !== fetchSerialRef.current) return
@@ -219,8 +187,10 @@ export function WaffoPancakeSettingsSection(props: Props) {
 
       setCatalog(stores)
       if (preselect) {
-        setChosenStoreID(preselect.storeID ?? '')
-        setChosenProductID(preselect.productID ?? '')
+        onSelectedBindingChange({
+          storeID: preselect.storeID ?? '',
+          productID: preselect.productID ?? '',
+        })
       } else {
         // Default anchor: bound product if found, else first product of
         // the first store with any — saves a click for new operators.
@@ -228,28 +198,31 @@ export function WaffoPancakeSettingsSection(props: Props) {
           s.onetimeProducts.some((p) => p.id === productID)
         )
         if (boundStore && productID) {
-          setChosenStoreID(boundStore.id)
-          setChosenProductID(productID)
+          onSelectedBindingChange({
+            storeID: boundStore.id,
+            productID,
+          })
         } else {
           const storeWithProducts = stores.find(
             (s) => s.onetimeProducts.length > 0
           )
           if (storeWithProducts) {
-            setChosenStoreID(storeWithProducts.id)
-            setChosenProductID(storeWithProducts.onetimeProducts[0].id)
+            onSelectedBindingChange({
+              storeID: storeWithProducts.id,
+              productID: storeWithProducts.onetimeProducts[0].id,
+            })
           } else {
-            setChosenStoreID('')
-            setChosenProductID('')
+            onSelectedBindingChange({ storeID: '', productID: '' })
           }
         }
       }
       setPhase('idle')
     },
-    [productID, t]
+    [onSelectedBindingChange, productID, t]
   )
 
-  const watchedMerchantID = form.watch('WaffoPancakeMerchantID') || ''
-  const watchedPrivateKey = form.watch('WaffoPancakePrivateKey') || ''
+  const watchedMerchantID = values.WaffoPancakeMerchantID || ''
+  const watchedPrivateKey = values.WaffoPancakePrivateKey || ''
   React.useEffect(() => {
     const m = watchedMerchantID.trim()
     const k = watchedPrivateKey.trim()
@@ -270,20 +243,23 @@ export function WaffoPancakeSettingsSection(props: Props) {
   const initialLoadRef = React.useRef(false)
   React.useEffect(() => {
     if (initialLoadRef.current) return
-    if (!props.defaultValues.WaffoPancakeMerchantID.trim()) return
+    if (!defaultValues.WaffoPancakeMerchantID.trim()) return
     initialLoadRef.current = true
-    setPhase('verifying')
-    void verifyAndFetchCatalog('', '')
-  }, [props.defaultValues.WaffoPancakeMerchantID, verifyAndFetchCatalog])
+    const timer = window.setTimeout(() => {
+      setPhase('verifying')
+      void verifyAndFetchCatalog('', '')
+    }, 0)
+    return () => window.clearTimeout(timer)
+  }, [defaultValues.WaffoPancakeMerchantID, verifyAndFetchCatalog])
 
   // Returns typed creds when the operator edited either field; otherwise
   // blanks so the backend falls back to persisted creds. Without this,
   // returning admins (saved merchant ID but empty key field) would send
   // a mixed-state body that the backend rejects.
   const readCreds = () => {
-    const formMerchant = (form.getValues('WaffoPancakeMerchantID') || '').trim()
-    const formKey = (form.getValues('WaffoPancakePrivateKey') || '').trim()
-    const saved = (props.defaultValues.WaffoPancakeMerchantID || '').trim()
+    const formMerchant = (values.WaffoPancakeMerchantID || '').trim()
+    const formKey = (values.WaffoPancakePrivateKey || '').trim()
+    const saved = (defaultValues.WaffoPancakeMerchantID || '').trim()
     const edited = formMerchant !== saved || formKey.length > 0
     if (!edited) return { merchantID: '', privateKey: '' }
     return { merchantID: formMerchant, privateKey: formKey }
@@ -362,66 +338,12 @@ export function WaffoPancakeSettingsSection(props: Props) {
     }
   }
 
-  const handleSave = async () => {
-    // Sends raw form values (not readCreds): SaveWaffoPancakeConfig already
-    // treats a blank PrivateKey as "keep existing", and MerchantID stays
-    // populated from props for returning admins.
-    const merchantID = (form.getValues('WaffoPancakeMerchantID') || '').trim()
-    const privateKey = (form.getValues('WaffoPancakePrivateKey') || '').trim()
-    if (!merchantID) {
-      toast.error(t('Merchant ID is required'))
-      return
-    }
-    if (!chosenStoreID || !chosenProductID) {
-      toast.error(t('Pick or create both a store and a product before saving.'))
-      return
-    }
-    setPhase('saving')
-    try {
-      const body = await saveWaffoPancakeConfig({
-        merchantID,
-        privateKey,
-        returnURL: removeTrailingSlash(returnURL.trim()),
-        storeID: chosenStoreID,
-        productID: chosenProductID,
-      })
-      if (
-        body?.message === 'success' &&
-        typeof body.data === 'object' &&
-        body.data
-      ) {
-        const saved = body.data as { product_id: string; store_id: string }
-        setStoreID(saved.store_id)
-        setProductID(saved.product_id)
-        toast.success(t('Waffo Pancake settings saved'))
-      } else {
-        const reason = typeof body?.data === 'string' ? body.data : undefined
-        toast.error(
-          reason
-            ? `${t('Waffo Pancake save failed')}: ${reason}`
-            : t('Waffo Pancake save failed')
-        )
-      }
-    } catch (err) {
-      toast.error(
-        `${t('Waffo Pancake save failed')}: ${
-          err instanceof Error ? err.message : String(err)
-        }`
-      )
-    } finally {
-      setPhase('idle')
-    }
-  }
-
   const verifying = phase === 'verifying'
-  const saving = phase === 'saving'
 
   // "Not edited" = MerchantID unchanged AND PrivateKey field blank, in
   // which case the backend falls back to persisted creds. Otherwise we
   // require both fields filled (mixed states would fail signature check).
-  const savedMerchantID = (
-    props.defaultValues.WaffoPancakeMerchantID || ''
-  ).trim()
+  const savedMerchantID = (defaultValues.WaffoPancakeMerchantID || '').trim()
   const formMerchantID = watchedMerchantID.trim()
   const formPrivateKey = watchedPrivateKey.trim()
   const credsEdited =
@@ -459,93 +381,74 @@ export function WaffoPancakeSettingsSection(props: Props) {
           )}
         </p>
       </div>
-      <Form {...form}>
-        <form
-          onSubmit={(e) => e.preventDefault()}
-          className='space-y-4'
-          data-no-autosubmit='true'
-        >
-          {/* Blue box — webhook configuration only. */}
-          <div className='rounded-md bg-blue-50 p-4 text-sm text-blue-900 dark:bg-blue-950 dark:text-blue-100'>
-            <p className='mb-2 font-medium'>{t('Webhook Configuration:')}</p>
-            <ul className='list-inside list-disc space-y-1'>
-              <li>
-                {t('Webhook URL (Test):')}{' '}
-                <code className='rounded bg-blue-100 px-1 py-0.5 text-xs dark:bg-blue-900'>
-                  {'<ServerAddress>/api/waffo-pancake/webhook/test'}
-                </code>
-              </li>
-              <li>
-                {t('Webhook URL (Production):')}{' '}
-                <code className='rounded bg-blue-100 px-1 py-0.5 text-xs dark:bg-blue-900'>
-                  {'<ServerAddress>/api/waffo-pancake/webhook/prod'}
-                </code>
-              </li>
-              <li>
-                {t(
-                  'Register each URL into the matching Test Mode / Production Mode webhook slot in the Pancake dashboard. Separate endpoints prevent test traffic from accidentally crediting production accounts.'
-                )}
-              </li>
-              <li>
-                {t('Configure at:')}{' '}
-                <a
-                  href={PANCAKE_DASHBOARD_URL}
-                  target='_blank'
-                  rel='noreferrer'
-                  className='underline hover:no-underline'
-                >
-                  {t('Waffo Pancake Dashboard')}
-                </a>
-              </li>
-            </ul>
-          </div>
+      <div className='grid min-w-0 gap-x-5 gap-y-4 lg:grid-cols-2'>
+        {/* Blue box — webhook configuration only. */}
+        <div className='rounded-md bg-blue-50 p-4 text-sm text-blue-900 lg:col-span-2 dark:bg-blue-950 dark:text-blue-100'>
+          <p className='mb-2 font-medium'>{t('Webhook Configuration:')}</p>
+          <ul className='list-inside list-disc space-y-1'>
+            <li>
+              {t('Webhook URL (Test):')}{' '}
+              <code className='rounded bg-blue-100 px-1 py-0.5 text-xs dark:bg-blue-900'>
+                {'<ServerAddress>/api/waffo-pancake/webhook/test'}
+              </code>
+            </li>
+            <li>
+              {t('Webhook URL (Production):')}{' '}
+              <code className='rounded bg-blue-100 px-1 py-0.5 text-xs dark:bg-blue-900'>
+                {'<ServerAddress>/api/waffo-pancake/webhook/prod'}
+              </code>
+            </li>
+            <li>
+              {t(
+                'Register each URL into the matching Test Mode / Production Mode webhook slot in the Pancake dashboard. Separate endpoints prevent test traffic from accidentally crediting production accounts.'
+              )}
+            </li>
+            <li>
+              {t('Configure at:')}{' '}
+              <a
+                href={PANCAKE_DASHBOARD_URL}
+                target='_blank'
+                rel='noreferrer'
+                className='underline hover:no-underline'
+              >
+                {t('Waffo Pancake Dashboard')}
+              </a>
+            </li>
+          </ul>
+        </div>
 
-          <FormField
-            control={form.control}
-            name='WaffoPancakeMerchantID'
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>{t('Merchant ID')}</FormLabel>
-                <FormControl>
-                  <Input
-                    placeholder='MER_xxx'
-                    autoComplete='off'
-                    {...field}
-                    onChange={(event) => field.onChange(event.target.value)}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
+        <div className='grid gap-1.5'>
+          <Label>{t('Merchant ID')}</Label>
+          <Input
+            placeholder='MER_xxx'
+            autoComplete='off'
+            value={values.WaffoPancakeMerchantID}
+            onChange={(event) =>
+              onValueChange('WaffoPancakeMerchantID', event.target.value)
+            }
           />
+        </div>
 
-          <FormField
-            control={form.control}
-            name='WaffoPancakePrivateKey'
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>{t('API Private Key')}</FormLabel>
-                <FormControl>
-                  <Textarea
-                    rows={4}
-                    placeholder={t('Leave blank to keep the existing key')}
-                    autoComplete='new-password'
-                    {...field}
-                    onChange={(event) => field.onChange(event.target.value)}
-                    className='font-mono text-xs'
-                  />
-                </FormControl>
-                <p className='text-muted-foreground text-xs'>
-                  {t(
-                    'The environment (test vs production) is decided by the key you paste here — use the Test key while integrating, then swap to the Production key when going live.'
-                  )}
-                </p>
-                <FormMessage />
-              </FormItem>
-            )}
+        <div className='grid gap-1.5'>
+          <Label>{t('API Private Key')}</Label>
+          <Textarea
+            rows={4}
+            placeholder={t('Leave blank to keep the existing key')}
+            autoComplete='new-password'
+            value={values.WaffoPancakePrivateKey}
+            onChange={(event) =>
+              onValueChange('WaffoPancakePrivateKey', event.target.value)
+            }
+            className='font-mono text-xs'
           />
+          <p className='text-muted-foreground text-xs'>
+            {t(
+              'The environment (test vs production) is decided by the key you paste here — use the Test key while integrating, then swap to the Production key when going live.'
+            )}
+          </p>
+        </div>
 
-          {/*
+        {/*
           Binding section — split into two visually distinct paths:
           (A) "Use existing" pair from the loaded catalog — only rendered when
               the merchant actually has stores, so first-time setup isn't
@@ -555,167 +458,164 @@ export function WaffoPancakeSettingsSection(props: Props) {
           The two paths are split by an "or" divider so the operator never has
           to wonder which field belongs to which intent.
         */}
-          <div className='space-y-4 pt-2'>
-            <div>
-              <h4 className='font-medium'>
-                {t('Bind a Pancake store + product')}
-              </h4>
-              <p className='text-muted-foreground text-xs'>
-                {bindStatusMessage}
-              </p>
-            </div>
+        <div className='space-y-4 pt-2 lg:col-span-2'>
+          <div>
+            <h4 className='font-medium'>
+              {t('Bind a Pancake store + product')}
+            </h4>
+            <p className='text-muted-foreground text-xs'>{bindStatusMessage}</p>
+          </div>
 
-            {/*
+          {/*
               Operator-facing explainer: why only ONE store + product needs
               to be bound at the gateway level, and what each piece is used
               for. Subscriptions reuse the same Store but get their own
               per-plan product, configured in the Subscriptions admin.
             */}
-            <div className='rounded-md border border-blue-200 bg-blue-50 p-3 text-xs text-blue-900 dark:border-blue-900/60 dark:bg-blue-950/40 dark:text-blue-100'>
-              <p className='mb-1 font-medium'>
-                {t('Why only one store + product?')}
-              </p>
-              <ul className='list-inside list-disc space-y-1'>
-                <li>
-                  {t(
-                    'The bound Store is the parent container for every Pancake product new-api creates from this admin — both the wallet top-up product and any subscription-plan products. One store is enough; pin a different one only if you genuinely run separate Pancake catalogs.'
-                  )}
-                </li>
-                <li>
-                  {t(
-                    'The bound Product powers wallet top-ups: when a user enters any amount, new-api runs the checkout against this single Pancake product and overrides the price per session — no need to pre-create $1 / $5 / $10 SKUs.'
-                  )}
-                </li>
-                <li>
-                  {t(
-                    'Subscription plans do NOT use the bound Product — each plan has its own dedicated Pancake product, set in the Subscriptions admin (or auto-minted via the "+ Create" button there).'
-                  )}
-                </li>
-              </ul>
-            </div>
-
-            {/* Create section — first, since creating auto-fills the pick-existing dropdowns below. */}
-            <div className='space-y-1.5'>
-              <Label>{t('Payment return URL')}</Label>
-              <div className='flex gap-2'>
-                <Input
-                  placeholder='https://example.com/console/topup'
-                  value={returnURL}
-                  onChange={(event) => setReturnURL(event.target.value)}
-                  className='flex-1'
-                />
-                <Button
-                  type='button'
-                  variant='outline'
-                  onClick={handleCreatePair}
-                  disabled={creatingPair || verifying || !credsReady}
-                  className='shrink-0'
-                >
-                  {creatingPair
-                    ? t('Creating...')
-                    : `+ ${t('Create')} ${DEFAULT_NEW_PAIR_NAME}`}
-                </Button>
-              </div>
-              <p className='text-muted-foreground text-xs'>
+          <div className='rounded-md border border-blue-200 bg-blue-50 p-3 text-xs text-blue-900 dark:border-blue-900/60 dark:bg-blue-950/40 dark:text-blue-100'>
+            <p className='mb-1 font-medium'>
+              {t('Why only one store + product?')}
+            </p>
+            <ul className='list-inside list-disc space-y-1'>
+              <li>
                 {t(
-                  "Used as SuccessURL on the new product. You'll be prompted to confirm if left blank."
+                  'The bound Store is the parent container for every Pancake product new-api creates from this admin — both the wallet top-up product and any subscription-plan products. One store is enough; pin a different one only if you genuinely run separate Pancake catalogs.'
                 )}
-              </p>
-            </div>
+              </li>
+              <li>
+                {t(
+                  'The bound Product powers wallet top-ups: when a user enters any amount, new-api runs the checkout against this single Pancake product and overrides the price per session — no need to pre-create $1 / $5 / $10 SKUs.'
+                )}
+              </li>
+              <li>
+                {t(
+                  'Subscription plans do NOT use the bound Product — each plan has its own dedicated Pancake product, set in the Subscriptions admin (or auto-minted via the "+ Create" button there).'
+                )}
+              </li>
+            </ul>
+          </div>
 
-            {hasCatalog ? (
-              <>
-                <div className='relative flex items-center py-1'>
-                  <div className='flex-1 border-t' />
-                  <span className='text-muted-foreground px-3 text-[10px] font-medium tracking-[0.2em] uppercase'>
-                    {t('or pick existing')}
-                  </span>
-                  <div className='flex-1 border-t' />
-                </div>
-
-                <div className='grid grid-cols-2 gap-3'>
-                  <div className='grid gap-1.5'>
-                    <Label>{t('Store')}</Label>
-                    <Select
-                      items={storeSelectItems}
-                      value={chosenStoreID}
-                      onValueChange={(value) => {
-                        // Base UI Select can deliver null on deselect.
-                        setChosenStoreID(value ?? '')
-                        setChosenProductID('')
-                      }}
-                    >
-                      <SelectTrigger className='w-full'>
-                        <SelectValue placeholder={t('Select a store')} />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {storeSelectItems.map((item) => (
-                          <SelectItem key={item.value} value={item.value}>
-                            {item.label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-
-                  <div className='grid gap-1.5'>
-                    <Label>{t('Product')}</Label>
-                    <Select
-                      items={productSelectItems}
-                      value={chosenProductID}
-                      onValueChange={(value) => setChosenProductID(value ?? '')}
-                      disabled={
-                        !chosenStoreID || productSelectItems.length === 0
-                      }
-                    >
-                      <SelectTrigger className='w-full'>
-                        <SelectValue placeholder={t('Select a product')} />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {productSelectItems.map((item) => (
-                          <SelectItem key={item.value} value={item.value}>
-                            {item.label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                </div>
-              </>
-            ) : null}
-
-            <div className='flex items-center gap-3'>
+          {/* Create section — first, since creating auto-fills the pick-existing dropdowns below. */}
+          <div className='space-y-1.5'>
+            <Label>{t('Payment return URL')}</Label>
+            <div className='flex gap-2'>
+              <Input
+                placeholder='https://example.com/console/topup'
+                value={returnURL}
+                onChange={(event) =>
+                  onValueChange('WaffoPancakeReturnURL', event.target.value)
+                }
+                className='flex-1'
+              />
               <Button
                 type='button'
-                onClick={handleSave}
-                disabled={saving || !chosenStoreID || !chosenProductID}
+                variant='outline'
+                onClick={handleCreatePair}
+                disabled={creatingPair || verifying || !credsReady}
+                className='shrink-0'
               >
-                {saving ? t('Saving...') : t('Save Waffo Pancake settings')}
+                {creatingPair
+                  ? t('Creating...')
+                  : `+ ${t('Create')} ${DEFAULT_NEW_PAIR_NAME}`}
               </Button>
-              {storeID || productID ? (
-                <div className='text-muted-foreground flex flex-wrap gap-x-3 gap-y-1 text-xs'>
-                  {storeID ? (
-                    <span>
-                      {t('Bound store:')}{' '}
-                      <code className='bg-muted rounded px-1 py-0.5'>
-                        {storeID}
-                      </code>
-                    </span>
-                  ) : null}
-                  {productID ? (
-                    <span>
-                      {t('Bound product:')}{' '}
-                      <code className='bg-muted rounded px-1 py-0.5'>
-                        {productID}
-                      </code>
-                    </span>
-                  ) : null}
-                </div>
-              ) : null}
             </div>
+            <p className='text-muted-foreground text-xs'>
+              {t(
+                "Used as SuccessURL on the new product. You'll be prompted to confirm if left blank."
+              )}
+            </p>
           </div>
-        </form>
-      </Form>
+
+          {hasCatalog ? (
+            <>
+              <div className='relative flex items-center py-1'>
+                <div className='flex-1 border-t' />
+                <span className='text-muted-foreground px-3 text-[10px] font-medium tracking-[0.2em] uppercase'>
+                  {t('or pick existing')}
+                </span>
+                <div className='flex-1 border-t' />
+              </div>
+
+              <div className='grid grid-cols-2 gap-3'>
+                <div className='grid gap-1.5'>
+                  <Label>{t('Store')}</Label>
+                  <Select
+                    items={storeSelectItems}
+                    value={chosenStoreID}
+                    onValueChange={(value) => {
+                      // Base UI Select can deliver null on deselect.
+                      onSelectedBindingChange({
+                        storeID: value ?? '',
+                        productID: '',
+                      })
+                    }}
+                  >
+                    <SelectTrigger className='w-full'>
+                      <SelectValue placeholder={t('Select a store')} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {storeSelectItems.map((item) => (
+                        <SelectItem key={item.value} value={item.value}>
+                          {item.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className='grid gap-1.5'>
+                  <Label>{t('Product')}</Label>
+                  <Select
+                    items={productSelectItems}
+                    value={chosenProductID}
+                    onValueChange={(value) =>
+                      onSelectedBindingChange((previous) => ({
+                        ...previous,
+                        productID: value ?? '',
+                      }))
+                    }
+                    disabled={!chosenStoreID || productSelectItems.length === 0}
+                  >
+                    <SelectTrigger className='w-full'>
+                      <SelectValue placeholder={t('Select a product')} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {productSelectItems.map((item) => (
+                        <SelectItem key={item.value} value={item.value}>
+                          {item.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            </>
+          ) : null}
+
+          <div className='flex items-center gap-3'>
+            {storeID || productID ? (
+              <div className='text-muted-foreground flex flex-wrap gap-x-3 gap-y-1 text-xs'>
+                {storeID ? (
+                  <span>
+                    {t('Bound store:')}{' '}
+                    <code className='bg-muted rounded px-1 py-0.5'>
+                      {storeID}
+                    </code>
+                  </span>
+                ) : null}
+                {productID ? (
+                  <span>
+                    {t('Bound product:')}{' '}
+                    <code className='bg-muted rounded px-1 py-0.5'>
+                      {productID}
+                    </code>
+                  </span>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
     </div>
   )
 }

--- a/web/default/src/features/system-settings/integrations/waffo-settings-section.tsx
+++ b/web/default/src/features/system-settings/integrations/waffo-settings-section.tsx
@@ -16,34 +16,19 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { type ChangeEvent, useEffect, useRef, useState } from 'react'
-import { useForm } from 'react-hook-form'
+import { type ChangeEvent, useRef, type SetStateAction, useState } from 'react'
 import { Plus, Pencil, Trash2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Separator } from '@/components/ui/separator'
-import { Switch } from '@/components/ui/switch'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table'
 import { Textarea } from '@/components/ui/textarea'
-import { useUpdateOption } from '../hooks/use-update-option'
+import { StaticDataTable } from '@/components/data-table'
+import { Dialog } from '@/components/dialog'
+import { SettingsSwitchField } from '../components/settings-form-layout'
 
 export interface WaffoSettingsValues {
   WaffoEnabled: boolean
@@ -63,34 +48,33 @@ export interface WaffoSettingsValues {
   WaffoPayMethods: string
 }
 
-interface PayMethod {
+export interface PayMethod {
   name: string
   icon: string
   payMethodType: string
   payMethodName: string
 }
 
+type WaffoFieldValues = Omit<WaffoSettingsValues, 'WaffoPayMethods'>
+
 interface Props {
-  defaultValues: WaffoSettingsValues
+  values: WaffoSettingsValues
+  onValueChange: <K extends keyof WaffoFieldValues>(
+    key: K,
+    value: WaffoFieldValues[K]
+  ) => void
+  payMethods: PayMethod[]
+  onPayMethodsChange: (value: SetStateAction<PayMethod[]>) => void
 }
 
-export function WaffoSettingsSection(props: Props) {
+export function WaffoSettingsSection({
+  values,
+  onValueChange,
+  payMethods,
+  onPayMethodsChange,
+}: Props) {
   const { t } = useTranslation()
-  const updateOption = useUpdateOption()
-  const [loading, setLoading] = useState(false)
   const iconFileInputRef = useRef<HTMLInputElement | null>(null)
-
-  const form = useForm<Omit<WaffoSettingsValues, 'WaffoPayMethods'>>({
-    defaultValues: props.defaultValues,
-  })
-
-  const [payMethods, setPayMethods] = useState<PayMethod[]>(() => {
-    try {
-      return JSON.parse(props.defaultValues.WaffoPayMethods || '[]')
-    } catch {
-      return []
-    }
-  })
   const [methodDialogOpen, setMethodDialogOpen] = useState(false)
   const [editingIdx, setEditingIdx] = useState(-1)
   const [methodForm, setMethodForm] = useState<PayMethod>({
@@ -99,61 +83,6 @@ export function WaffoSettingsSection(props: Props) {
     payMethodType: '',
     payMethodName: '',
   })
-
-  useEffect(() => {
-    form.reset(props.defaultValues)
-    try {
-      setPayMethods(JSON.parse(props.defaultValues.WaffoPayMethods || '[]'))
-    } catch {
-      setPayMethods([])
-    }
-  }, [props.defaultValues, form])
-
-  const handleSave = async () => {
-    setLoading(true)
-    try {
-      const values = form.getValues()
-      const options: { key: string; value: string }[] = [
-        { key: 'WaffoEnabled', value: String(values.WaffoEnabled) },
-        { key: 'WaffoSandbox', value: String(values.WaffoSandbox) },
-        { key: 'WaffoMerchantId', value: values.WaffoMerchantId || '' },
-        { key: 'WaffoCurrency', value: values.WaffoCurrency || 'USD' },
-        { key: 'WaffoUnitPrice', value: String(values.WaffoUnitPrice || 1) },
-        { key: 'WaffoMinTopUp', value: String(values.WaffoMinTopUp || 1) },
-        { key: 'WaffoNotifyUrl', value: values.WaffoNotifyUrl || '' },
-        { key: 'WaffoReturnUrl', value: values.WaffoReturnUrl || '' },
-        { key: 'WaffoPublicCert', value: values.WaffoPublicCert || '' },
-        {
-          key: 'WaffoSandboxPublicCert',
-          value: values.WaffoSandboxPublicCert || '',
-        },
-        { key: 'WaffoPayMethods', value: JSON.stringify(payMethods) },
-      ]
-      if (values.WaffoApiKey)
-        options.push({ key: 'WaffoApiKey', value: values.WaffoApiKey })
-      if (values.WaffoPrivateKey)
-        options.push({ key: 'WaffoPrivateKey', value: values.WaffoPrivateKey })
-      if (values.WaffoSandboxApiKey)
-        options.push({
-          key: 'WaffoSandboxApiKey',
-          value: values.WaffoSandboxApiKey,
-        })
-      if (values.WaffoSandboxPrivateKey)
-        options.push({
-          key: 'WaffoSandboxPrivateKey',
-          value: values.WaffoSandboxPrivateKey,
-        })
-
-      for (const opt of options) {
-        await updateOption.mutateAsync(opt)
-      }
-      toast.success(t('Updated successfully'))
-    } catch {
-      toast.error(t('Update failed'))
-    } finally {
-      setLoading(false)
-    }
-  }
 
   const openAdd = () => {
     setEditingIdx(-1)
@@ -171,9 +100,9 @@ export function WaffoSettingsSection(props: Props) {
     if (!methodForm.name.trim())
       return toast.error(t('Payment method name is required'))
     if (editingIdx === -1) {
-      setPayMethods((prev) => [...prev, methodForm])
+      onPayMethodsChange((prev) => [...prev, methodForm])
     } else {
-      setPayMethods((prev) =>
+      onPayMethodsChange((prev) =>
         prev.map((m, i) => (i === editingIdx ? methodForm : m))
       )
     }
@@ -230,37 +159,52 @@ export function WaffoSettingsSection(props: Props) {
           </AlertDescription>
         </Alert>
 
-        <div className='grid grid-cols-2 gap-4'>
-          <div className='flex items-center gap-2'>
-            <Switch
-              checked={form.watch('WaffoEnabled')}
-              onCheckedChange={(v) => form.setValue('WaffoEnabled', v)}
-            />
-            <Label>{t('Enable Waffo')}</Label>
-          </div>
-          <div className='flex items-center gap-2'>
-            <Switch
-              checked={form.watch('WaffoSandbox')}
-              onCheckedChange={(v) => form.setValue('WaffoSandbox', v)}
-            />
-            <Label>{t('Sandbox mode')}</Label>
-          </div>
+        <div className='grid gap-4 sm:grid-cols-2'>
+          <SettingsSwitchField
+            checked={values.WaffoEnabled}
+            onCheckedChange={(v) => onValueChange('WaffoEnabled', v)}
+            label={t('Enable Waffo')}
+            className='border-b-0 py-0'
+          />
+          <SettingsSwitchField
+            checked={values.WaffoSandbox}
+            onCheckedChange={(v) => onValueChange('WaffoSandbox', v)}
+            label={t('Sandbox mode')}
+            className='border-b-0 py-0'
+          />
         </div>
 
         <div className='grid grid-cols-2 gap-4'>
           <div className='grid gap-1.5'>
             <Label>{t('API Key (Production)')}</Label>
-            <Input type='password' {...form.register('WaffoApiKey')} />
+            <Input
+              type='password'
+              value={values.WaffoApiKey}
+              onChange={(event) =>
+                onValueChange('WaffoApiKey', event.target.value)
+              }
+            />
           </div>
           <div className='grid gap-1.5'>
             <Label>{t('API Key (Sandbox)')}</Label>
-            <Input type='password' {...form.register('WaffoSandboxApiKey')} />
+            <Input
+              type='password'
+              value={values.WaffoSandboxApiKey}
+              onChange={(event) =>
+                onValueChange('WaffoSandboxApiKey', event.target.value)
+              }
+            />
           </div>
         </div>
 
         <div className='grid gap-1.5'>
           <Label>{t('Merchant ID')}</Label>
-          <Input {...form.register('WaffoMerchantId')} />
+          <Input
+            value={values.WaffoMerchantId}
+            onChange={(event) =>
+              onValueChange('WaffoMerchantId', event.target.value)
+            }
+          />
         </div>
 
         <div className='grid grid-cols-2 gap-4'>
@@ -268,7 +212,10 @@ export function WaffoSettingsSection(props: Props) {
             <Label>{t('RSA Private Key (Production)')}</Label>
             <Textarea
               rows={3}
-              {...form.register('WaffoPrivateKey')}
+              value={values.WaffoPrivateKey}
+              onChange={(event) =>
+                onValueChange('WaffoPrivateKey', event.target.value)
+              }
               className='font-mono text-xs'
             />
           </div>
@@ -276,7 +223,10 @@ export function WaffoSettingsSection(props: Props) {
             <Label>{t('RSA Private Key (Sandbox)')}</Label>
             <Textarea
               rows={3}
-              {...form.register('WaffoSandboxPrivateKey')}
+              value={values.WaffoSandboxPrivateKey}
+              onChange={(event) =>
+                onValueChange('WaffoSandboxPrivateKey', event.target.value)
+              }
               className='font-mono text-xs'
             />
           </div>
@@ -287,7 +237,10 @@ export function WaffoSettingsSection(props: Props) {
             <Label>{t('Waffo Public Key (Production)')}</Label>
             <Textarea
               rows={3}
-              {...form.register('WaffoPublicCert')}
+              value={values.WaffoPublicCert}
+              onChange={(event) =>
+                onValueChange('WaffoPublicCert', event.target.value)
+              }
               className='font-mono text-xs'
             />
           </div>
@@ -295,7 +248,10 @@ export function WaffoSettingsSection(props: Props) {
             <Label>{t('Waffo Public Key (Sandbox)')}</Label>
             <Textarea
               rows={3}
-              {...form.register('WaffoSandboxPublicCert')}
+              value={values.WaffoSandboxPublicCert}
+              onChange={(event) =>
+                onValueChange('WaffoSandboxPublicCert', event.target.value)
+              }
               className='font-mono text-xs'
             />
           </div>
@@ -304,7 +260,7 @@ export function WaffoSettingsSection(props: Props) {
         <div className='grid grid-cols-3 gap-4'>
           <div className='grid gap-1.5'>
             <Label>{t('Currency')}</Label>
-            <Input {...form.register('WaffoCurrency')} disabled />
+            <Input value={values.WaffoCurrency} disabled />
           </div>
           <div className='grid gap-1.5'>
             <Label>{t('Unit price (USD)')}</Label>
@@ -312,12 +268,28 @@ export function WaffoSettingsSection(props: Props) {
               type='number'
               step={0.1}
               min={0}
-              {...form.register('WaffoUnitPrice')}
+              value={values.WaffoUnitPrice}
+              onChange={(event) =>
+                onValueChange(
+                  'WaffoUnitPrice',
+                  event.target.value === '' ? 0 : event.target.valueAsNumber
+                )
+              }
             />
           </div>
           <div className='grid gap-1.5'>
             <Label>{t('Minimum top-up quantity')}</Label>
-            <Input type='number' min={1} {...form.register('WaffoMinTopUp')} />
+            <Input
+              type='number'
+              min={1}
+              value={values.WaffoMinTopUp}
+              onChange={(event) =>
+                onValueChange(
+                  'WaffoMinTopUp',
+                  event.target.value === '' ? 1 : event.target.valueAsNumber
+                )
+              }
+            />
           </div>
         </div>
 
@@ -326,14 +298,20 @@ export function WaffoSettingsSection(props: Props) {
             <Label>{t('Callback notification URL')}</Label>
             <Input
               placeholder='https://example.com/api/waffo/webhook'
-              {...form.register('WaffoNotifyUrl')}
+              value={values.WaffoNotifyUrl}
+              onChange={(event) =>
+                onValueChange('WaffoNotifyUrl', event.target.value)
+              }
             />
           </div>
           <div className='grid gap-1.5'>
             <Label>{t('Payment return URL')}</Label>
             <Input
               placeholder='https://example.com/console/topup'
-              {...form.register('WaffoReturnUrl')}
+              value={values.WaffoReturnUrl}
+              onChange={(event) =>
+                onValueChange('WaffoReturnUrl', event.target.value)
+              }
             />
           </div>
         </div>
@@ -342,190 +320,190 @@ export function WaffoSettingsSection(props: Props) {
 
         <div className='flex items-center justify-between'>
           <h4 className='font-medium'>{t('Payment Methods')}</h4>
-          <Button variant='outline' size='sm' onClick={openAdd}>
+          <Button type='button' variant='outline' size='sm' onClick={openAdd}>
             <Plus className='mr-1 h-3 w-3' />
             {t('Add payment method')}
           </Button>
         </div>
 
-        <div className='rounded-md border'>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>{t('Display name')}</TableHead>
-                <TableHead>{t('Icon')}</TableHead>
-                <TableHead>{t('Payment method type')}</TableHead>
-                <TableHead>{t('Payment method name')}</TableHead>
-                <TableHead className='text-right'>{t('Actions')}</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {payMethods.length === 0 ? (
-                <TableRow>
-                  <TableCell
-                    colSpan={5}
-                    className='text-muted-foreground py-8 text-center'
-                  >
-                    {t('No payment methods configured')}
-                  </TableCell>
-                </TableRow>
-              ) : (
-                payMethods.map((m, idx) => (
-                  <TableRow key={idx}>
-                    <TableCell>{m.name}</TableCell>
-                    <TableCell>
-                      {m.icon ? (
-                        <img
-                          src={m.icon}
-                          alt={m.name}
-                          className='h-6 w-6 rounded object-contain'
-                        />
-                      ) : (
-                        <span className='text-muted-foreground'>-</span>
-                      )}
-                    </TableCell>
-                    <TableCell>{m.payMethodType || '-'}</TableCell>
-                    <TableCell>{m.payMethodName || '-'}</TableCell>
-                    <TableCell className='text-right'>
-                      <div className='flex justify-end gap-1'>
-                        <Button
-                          variant='ghost'
-                          size='icon'
-                          className='h-7 w-7'
-                          onClick={() => openEdit(idx)}
-                        >
-                          <Pencil className='h-3 w-3' />
-                        </Button>
-                        <Button
-                          variant='ghost'
-                          size='icon'
-                          className='h-7 w-7'
-                          onClick={() =>
-                            setPayMethods((prev) =>
-                              prev.filter((_, i) => i !== idx)
-                            )
-                          }
-                        >
-                          <Trash2 className='h-3 w-3' />
-                        </Button>
-                      </div>
-                    </TableCell>
-                  </TableRow>
-                ))
-              )}
-            </TableBody>
-          </Table>
-        </div>
-
-        <Button onClick={handleSave} disabled={loading}>
-          {loading ? t('Saving...') : t('Save Changes')}
-        </Button>
-      </div>
-
-      <Dialog open={methodDialogOpen} onOpenChange={setMethodDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>
-              {editingIdx === -1
-                ? t('Add payment method')
-                : t('Edit payment method')}
-            </DialogTitle>
-          </DialogHeader>
-          <div className='space-y-3'>
-            <div className='grid gap-1.5'>
-              <Label>{t('Display name')} *</Label>
-              <Input
-                value={methodForm.name}
-                onChange={(e) =>
-                  setMethodForm((p) => ({ ...p, name: e.target.value }))
-                }
-              />
-            </div>
-            <div className='grid gap-2'>
-              <Label>{t('Icon')}</Label>
-              <div className='flex items-center gap-3'>
-                {methodForm.icon ? (
+        <StaticDataTable
+          data={payMethods}
+          emptyClassName='text-muted-foreground py-8'
+          emptyContent={t('No payment methods configured')}
+          columns={[
+            {
+              id: 'name',
+              header: t('Display name'),
+              cell: (m) => m.name,
+            },
+            {
+              id: 'icon',
+              header: t('Icon'),
+              cell: (m) =>
+                m.icon ? (
                   <img
-                    src={methodForm.icon}
-                    alt={methodForm.name || t('Icon')}
-                    className='h-10 w-10 rounded border object-contain p-1'
+                    src={m.icon}
+                    alt={m.name}
+                    className='h-6 w-6 rounded object-contain'
                   />
                 ) : (
-                  <div className='bg-muted text-muted-foreground flex h-10 w-10 items-center justify-center rounded border text-xs'>
-                    {t('Icon')}
-                  </div>
-                )}
-                <input
-                  ref={iconFileInputRef}
-                  type='file'
-                  accept='image/png,image/jpeg,image/svg+xml,image/webp'
-                  className='hidden'
-                  onChange={handleIconFileChange}
-                />
-                <Button
-                  type='button'
-                  variant='outline'
-                  onClick={() => iconFileInputRef.current?.click()}
-                >
-                  {t('Upload')}
-                </Button>
-                {methodForm.icon ? (
+                  <span className='text-muted-foreground'>-</span>
+                ),
+            },
+            {
+              id: 'type',
+              header: t('Payment method type'),
+              cell: (m) => m.payMethodType || '-',
+            },
+            {
+              id: 'method',
+              header: t('Payment method name'),
+              cell: (m) => m.payMethodName || '-',
+            },
+            {
+              id: 'actions',
+              header: t('Actions'),
+              className: 'text-right',
+              cellClassName: 'text-right',
+              cell: (_m, idx) => (
+                <div className='flex justify-end gap-1'>
                   <Button
                     type='button'
-                    variant='outline'
+                    variant='ghost'
+                    size='icon'
+                    className='h-7 w-7'
+                    onClick={() => openEdit(idx)}
+                  >
+                    <Pencil className='h-3 w-3' />
+                  </Button>
+                  <Button
+                    type='button'
+                    variant='ghost'
+                    size='icon'
+                    className='h-7 w-7'
                     onClick={() =>
-                      setMethodForm((previous) => ({
-                        ...previous,
-                        icon: '',
-                      }))
+                      onPayMethodsChange((prev) =>
+                        prev.filter((_, i) => i !== idx)
+                      )
                     }
                   >
-                    {t('Clear')}
+                    <Trash2 className='h-3 w-3' />
                   </Button>
-                ) : null}
-              </div>
-              <p className='text-muted-foreground text-xs'>
-                {t(
-                  'Supports PNG, JPG, SVG, or WebP. Recommended size: 128×128 or smaller.'
-                )}
-              </p>
-            </div>
-            <div className='grid gap-1.5'>
-              <Label>{t('Payment method type')}</Label>
-              <Input
-                value={methodForm.payMethodType}
-                onChange={(e) =>
-                  setMethodForm((p) => ({
-                    ...p,
-                    payMethodType: e.target.value,
-                  }))
-                }
-                placeholder='CREDITCARD,DEBITCARD'
-              />
-            </div>
-            <div className='grid gap-1.5'>
-              <Label>{t('Payment method name')}</Label>
-              <Input
-                value={methodForm.payMethodName}
-                onChange={(e) =>
-                  setMethodForm((p) => ({
-                    ...p,
-                    payMethodName: e.target.value,
-                  }))
-                }
-              />
-            </div>
-          </div>
-          <DialogFooter>
+                </div>
+              ),
+            },
+          ]}
+        />
+      </div>
+
+      <Dialog
+        open={methodDialogOpen}
+        onOpenChange={setMethodDialogOpen}
+        title={
+          editingIdx === -1 ? t('Add payment method') : t('Edit payment method')
+        }
+        contentHeight='auto'
+        bodyClassName='space-y-4'
+        footer={
+          <>
             <Button
+              type='button'
               variant='outline'
               onClick={() => setMethodDialogOpen(false)}
             >
               {t('Cancel')}
             </Button>
-            <Button onClick={saveMethod}>{t('Confirm')}</Button>
-          </DialogFooter>
-        </DialogContent>
+            <Button type='button' onClick={saveMethod}>
+              {t('Confirm')}
+            </Button>
+          </>
+        }
+      >
+        <div className='space-y-3'>
+          <div className='grid gap-1.5'>
+            <Label>{t('Display name')} *</Label>
+            <Input
+              value={methodForm.name}
+              onChange={(e) =>
+                setMethodForm((p) => ({ ...p, name: e.target.value }))
+              }
+            />
+          </div>
+          <div className='grid gap-2'>
+            <Label>{t('Icon')}</Label>
+            <div className='flex items-center gap-3'>
+              {methodForm.icon ? (
+                <img
+                  src={methodForm.icon}
+                  alt={methodForm.name || t('Icon')}
+                  className='h-10 w-10 rounded border object-contain p-1'
+                />
+              ) : (
+                <div className='bg-muted text-muted-foreground flex h-10 w-10 items-center justify-center rounded border text-xs'>
+                  {t('Icon')}
+                </div>
+              )}
+              <input
+                ref={iconFileInputRef}
+                type='file'
+                accept='image/png,image/jpeg,image/svg+xml,image/webp'
+                className='hidden'
+                onChange={handleIconFileChange}
+              />
+              <Button
+                type='button'
+                variant='outline'
+                onClick={() => iconFileInputRef.current?.click()}
+              >
+                {t('Upload')}
+              </Button>
+              {methodForm.icon ? (
+                <Button
+                  type='button'
+                  variant='outline'
+                  onClick={() =>
+                    setMethodForm((previous) => ({
+                      ...previous,
+                      icon: '',
+                    }))
+                  }
+                >
+                  {t('Clear')}
+                </Button>
+              ) : null}
+            </div>
+            <p className='text-muted-foreground text-xs'>
+              {t(
+                'Supports PNG, JPG, SVG, or WebP. Recommended size: 128×128 or smaller.'
+              )}
+            </p>
+          </div>
+          <div className='grid gap-1.5'>
+            <Label>{t('Payment method type')}</Label>
+            <Input
+              value={methodForm.payMethodType}
+              onChange={(e) =>
+                setMethodForm((p) => ({
+                  ...p,
+                  payMethodType: e.target.value,
+                }))
+              }
+              placeholder='CREDITCARD,DEBITCARD'
+            />
+          </div>
+          <div className='grid gap-1.5'>
+            <Label>{t('Payment method name')}</Label>
+            <Input
+              value={methodForm.payMethodName}
+              onChange={(e) =>
+                setMethodForm((p) => ({
+                  ...p,
+                  payMethodName: e.target.value,
+                }))
+              }
+            />
+          </div>
+        </div>
       </Dialog>
     </>
   )

--- a/web/default/src/features/system-settings/integrations/wxpay-settings-section.tsx
+++ b/web/default/src/features/system-settings/integrations/wxpay-settings-section.tsx
@@ -16,12 +16,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { useEffect, useState } from 'react'
-import { useForm } from 'react-hook-form'
-import { useQueryClient } from '@tanstack/react-query'
+import type { UseFormReturn } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import { toast } from 'sonner'
-import { Button } from '@/components/ui/button'
 import {
   Form,
   FormControl,
@@ -35,8 +31,8 @@ import { Input } from '@/components/ui/input'
 import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
 import { SettingsSection } from '../components/settings-section'
-import { useUpdateOption } from '../hooks/use-update-option'
 import { isMaskedSecret } from './paypal-settings-section'
+import type { PaymentFormValues } from './payment-settings-section'
 
 export interface WxpaySettingsValues {
   WxpayEnabled: boolean
@@ -51,112 +47,82 @@ export interface WxpaySettingsValues {
 }
 
 interface Props {
-  defaultValues: WxpaySettingsValues
+  form: UseFormReturn<PaymentFormValues>
   serverAddress?: string
 }
 
-export function WxpaySettingsSection({ defaultValues, serverAddress }: Props) {
+type WxpayUpdate = { key: string; value: string }
+
+/**
+ * Build option updates for WeChat Pay using the same mask/changed guards as the
+ * original self-contained save. Credentials go in `options`; the Enabled switch
+ * is returned separately in `enable` so the caller persists it AFTER credentials
+ * (the backend rejects enable=true while credentials are empty).
+ */
+export function buildWxpayUpdates(
+  values: WxpaySettingsValues,
+  initial: WxpaySettingsValues
+): { options: WxpayUpdate[]; enable: WxpayUpdate | null } {
+  const options: WxpayUpdate[] = []
+
+  // Plain (non-secret) fields — push when changed
+  const plainFields: (keyof WxpaySettingsValues)[] = [
+    'WxpayAppId',
+    'WxpayMchId',
+    'WxpayMchSerialNo',
+    'WxpayPublicKeyId',
+  ]
+  for (const key of plainFields) {
+    if (values[key] !== initial[key]) {
+      options.push({ key, value: String(values[key] || '') })
+    }
+  }
+
+  // Secret fields — only push if not masked (i.e., actually edited)
+  if (values.WxpayApiV3Key && !isMaskedSecret(values.WxpayApiV3Key)) {
+    options.push({ key: 'WxpayApiV3Key', value: values.WxpayApiV3Key })
+  }
+  if (values.WxpayPrivateKey && !isMaskedSecret(values.WxpayPrivateKey)) {
+    options.push({ key: 'WxpayPrivateKey', value: values.WxpayPrivateKey })
+  }
+  if (values.WxpayPublicKey && !isMaskedSecret(values.WxpayPublicKey)) {
+    options.push({ key: 'WxpayPublicKey', value: values.WxpayPublicKey })
+  }
+
+  if (
+    values.WxpayMinTopUp !== undefined &&
+    values.WxpayMinTopUp !== null &&
+    values.WxpayMinTopUp !== initial.WxpayMinTopUp
+  ) {
+    options.push({
+      key: 'WxpayMinTopUp',
+      value: String(values.WxpayMinTopUp || 1),
+    })
+  }
+
+  // Enabled switch — persisted AFTER credentials by the caller.
+  let enable: WxpayUpdate | null = null
+  if (initial.WxpayEnabled !== values.WxpayEnabled) {
+    enable = { key: 'WxpayEnabled', value: String(values.WxpayEnabled) }
+  }
+
+  return { options, enable }
+}
+
+export function WxpaySettingsSection({ form, serverAddress }: Props) {
   const { t } = useTranslation()
-  const updateOption = useUpdateOption()
-  const queryClient = useQueryClient()
-  const [loading, setLoading] = useState(false)
-
-  const form = useForm<WxpaySettingsValues>({
-    defaultValues,
-  })
-
-  useEffect(() => {
-    form.reset(defaultValues)
-  }, [defaultValues, form])
 
   const notifyUrl = serverAddress
     ? `${serverAddress.replace(/\/+$/, '')}/api/user/wxpay/notify`
     : `<ServerAddress>/api/user/wxpay/notify`
 
-  const handleSave = async () => {
-    setLoading(true)
-    try {
-      const values = form.getValues()
-      const options: { key: string; value: string }[] = []
-
-      // Plain (non-secret) fields — push when changed
-      const plainFields: (keyof WxpaySettingsValues)[] = [
-        'WxpayAppId',
-        'WxpayMchId',
-        'WxpayMchSerialNo',
-        'WxpayPublicKeyId',
-      ]
-      for (const key of plainFields) {
-        if (values[key] !== defaultValues[key]) {
-          options.push({ key, value: String(values[key] || '') })
-        }
-      }
-
-      // Secret fields — only push if not masked (i.e., actually edited)
-      if (values.WxpayApiV3Key && !isMaskedSecret(values.WxpayApiV3Key)) {
-        options.push({ key: 'WxpayApiV3Key', value: values.WxpayApiV3Key })
-      }
-      if (values.WxpayPrivateKey && !isMaskedSecret(values.WxpayPrivateKey)) {
-        options.push({ key: 'WxpayPrivateKey', value: values.WxpayPrivateKey })
-      }
-      if (values.WxpayPublicKey && !isMaskedSecret(values.WxpayPublicKey)) {
-        options.push({ key: 'WxpayPublicKey', value: values.WxpayPublicKey })
-      }
-
-      if (
-        values.WxpayMinTopUp !== undefined &&
-        values.WxpayMinTopUp !== null &&
-        values.WxpayMinTopUp !== defaultValues.WxpayMinTopUp
-      ) {
-        options.push({
-          key: 'WxpayMinTopUp',
-          value: String(values.WxpayMinTopUp || 1),
-        })
-      }
-
-      // Enabled switch — saved AFTER credentials, because backend validation
-      // rejects enable=true when credentials are still empty
-      let enabledOption: { key: string; value: string } | null = null
-      if (defaultValues.WxpayEnabled !== values.WxpayEnabled) {
-        enabledOption = {
-          key: 'WxpayEnabled',
-          value: String(values.WxpayEnabled),
-        }
-      }
-
-      if (options.length === 0 && !enabledOption) {
-        toast.success(t('Updated successfully'))
-        setLoading(false)
-        return
-      }
-
-      for (const opt of options) {
-        await updateOption.mutateAsync(opt)
-      }
-      if (enabledOption) {
-        await updateOption.mutateAsync(enabledOption)
-      }
-      // Re-fetch options from the API. The backend strips sensitive fields
-      // (suffix Key/Secret/Token), so WxpayApiV3Key, WxpayPrivateKey, and
-      // WxpayPublicKey will come back empty. Non-sensitive fields like
-      // WxpayAppId, WxpayMchId, WxpayMchSerialNo, WxpayPublicKeyId,
-      // WxpayMinTopUp, WxpayEnabled will be re-populated with saved values.
-      await queryClient.invalidateQueries({ queryKey: ['system-options'] })
-      toast.success(t('Updated successfully'))
-    } catch {
-      toast.error(t('Update failed'))
-    } finally {
-      setLoading(false)
-    }
-  }
-
   return (
-    <SettingsSection
-      title={t('WeChat Pay Settings')}
-      description={t('Configure WeChat Pay payment gateway for top-ups')}
-    >
+    <SettingsSection title={t('WeChat Pay Settings')}>
+      <p className='text-muted-foreground text-sm'>
+        {t('Configure WeChat Pay payment gateway for top-ups')}
+      </p>
       <Form {...form}>
-        <form className='space-y-4'>
+        <div className='space-y-4'>
           {/* Blue info box */}
           <div className='rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-950'>
             <p className='text-sm text-blue-900 dark:text-blue-100'>
@@ -375,10 +341,7 @@ export function WxpaySettingsSection({ defaultValues, serverAddress }: Props) {
             />
           </div>
 
-          <Button type='button' onClick={handleSave} disabled={loading}>
-            {loading ? t('Saving...') : t('Save WeChat Pay settings')}
-          </Button>
-        </form>
+        </div>
       </Form>
     </SettingsSection>
   )


### PR DESCRIPTION
> [!NOTE]
> 本 PR 由 AI 辅助生成(git user `DreamLinx` 非本仓库历史核心作者,按项目约定显式声明)。描述已人工核对,变更逻辑与本地实测均经过确认。

## 📝 变更描述 / Description

upstream 重构了 `payment-settings-section`(平铺 section → Tabs 外壳),而我们 fork 在该文件是深度分叉。本 PR 不再维持整体 fork,而是**采纳 upstream 的重构,把 fork 专属的改动转成 upstream 之上的纯加法**。

深挖发现两边本就是同一架构模式(主容器 + per-provider section 子组件),真分叉只 3 点,全部增量化:

1. **基础组件还原 upstream**:`settings-section.tsx`、`section-page-layout.tsx` 去掉我们之前加回的 `description` prop / `Description` slot,回归 upstream(diff=0)。消费者改用 inline `<p>` 副标题(alipay/paypal/wxpay section + platforms 页)。
2. **waffo / waffo-pancake 取 upstream**:这两个本就是 upstream 功能,fork 的 `provisioned*` prop 上提已被 upstream 的 catalog-binding 流程取代。
3. **payment-settings-section 以 upstream Tabs 为 base**:fork 独有的 **Alipay / WeChat Pay / PayPal** 嫁接为 3 个**受控 tab**。

三个 exotic provider 从"自包含 form + 独立 save 按钮"改造为绑定父级 form 的受控组件,由顶部单一 **Save all settings** 经统一 `onSubmit` 持久化。每个 provider 的 save 逻辑**原样导出为纯 builder**(`buildAlipayUpdates` / `buildWxpayUpdates` / `buildPayPalUpdates`)——mask 跳过、changed-only diff、**enable 在凭证之后**的顺序均未改动。PayPal 保留 section 内独立 Disable 动作。

## 🚀 变更类型 / Type of change
- [x] ⚡ 性能优化 / 重构 (Refactor)

## 🔗 关联任务 / Related Issue
- 无(upstream sync 后的重构债清理:payment 组取 ours + 基础组件加回 prop 两项债务)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 描述已人工整理核对。
- [x] **非重复提交:** 已确认无重复。
- [x] **Bug fix 说明:** N/A(纯重构,无行为变更)。
- [x] **变更理解:** 已理解工作原理与影响;save 逻辑逐位等价迁移。
- [x] **范围聚焦:** 仅 payment 设置相关 9 文件,无无关改动。
- [x] **本地验证:** `tsc -b` 0 error;`bun run build` 通过;Playwright 浏览器 smoke 通过。
- [x] **安全合规:** 无敏感凭据;mask/clobber 保护经实测保留。

## 📸 运行证明 / Proof of Work

**编译/构建:**
- `bunx tsc -b` → 0 error(含 noUnusedLocals)
- `bun run build` → exit 0,dist 产物正常

**本地浏览器 smoke(Playwright 实操,独立临时 SQLite 库,未污染数据):**
| 验证项 | 结果 |
|---|---|
| 9 个 tab 全渲染(含嫁接的 Alipay/WeChat Pay/PayPal) | ✅ |
| 3 provider 受控渲染(inline description、无独立 save 按钮) | ✅ |
| 顶部统一 Save 写入变更字段(AppId/Enabled/非 mask 密文) | ✅ |
| 空密文留空 → 不写入(空值 guard) | ✅ |
| reload 后密文回显空,只改 AppId 再 save → 已存密文**不被覆盖**(clobber 保护) | ✅ |

mask 检测 / 延迟启用 / 逐字段提交三条不变式经统一 onSubmit 路径确认逻辑无损。