### PR TITLE
fix(relay): replayable request body for HTTP/2 GOAWAY retries (tokenpony 排队根因)

### DIFF
--- a/relay/channel/api_request.go
+++ b/relay/channel/api_request.go
@@ -1,6 +1,7 @@
 package channel
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -40,6 +41,32 @@ func applyUpstreamContentLength(req *http.Request, info *common.RelayInfo) {
 	if info.UpstreamRequestBodySize > 0 && req.ContentLength <= 0 {
 		req.ContentLength = info.UpstreamRequestBodySize
 	}
+}
+
+// replayBodyLimit caps the upstream request body size (bytes) that DoApiRequest
+// buffers into RAM so net/http can replay it on an HTTP/2 GOAWAY / PROTOCOL_ERROR
+// mid-stream retry. net/http auto-installs Request.GetBody (and ContentLength) for
+// *bytes.Reader; without GetBody, a peer PROTOCOL_ERROR arriving after the body was
+// written fails as "cannot retry ... define Request.GetBody" and surfaces to the
+// client as a 500 (tokenpony sends these under concurrent load). Bodies at/above
+// this limit — typically disk-backed vision/image uploads — pass through unbuffered
+// and stay non-replayable, trading retry-safety for OOM-safety.
+const replayBodyLimit = 1 << 20 // 1 MiB
+
+// makeReplayableBody returns a body net/http can replay on HTTP/2 mid-stream
+// retries. Bodies whose size is known and <= replayBodyLimit are buffered into a
+// *bytes.Reader (http.NewRequest then auto-sets GetBody + ContentLength). Larger,
+// unknown-size, or nil-info bodies pass through unchanged (no GetBody) to avoid
+// materializing disk-backed or oversized payloads into RAM.
+func makeReplayableBody(requestBody io.Reader, info *common.RelayInfo) (io.Reader, error) {
+	if info == nil || info.UpstreamRequestBodySize <= 0 || info.UpstreamRequestBodySize > replayBodyLimit {
+		return requestBody, nil
+	}
+	bodyBytes, err := io.ReadAll(requestBody)
+	if err != nil {
+		return nil, fmt.Errorf("buffer replayable request body: %w", err)
+	}
+	return bytes.NewReader(bodyBytes), nil
 }
 
 func SetupApiRequestHeader(info *common.RelayInfo, c *gin.Context, req *http.Header) {
@@ -310,7 +337,11 @@ func DoApiRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBody
 		return nil, fmt.Errorf("get request url failed: %w", err)
 	}
 	logger.LogDebug(c, "fullRequestURL: %s", fullRequestURL)
-	req, err := http.NewRequest(c.Request.Method, fullRequestURL, requestBody)
+	replayBody, err := makeReplayableBody(requestBody, info)
+	if err != nil {
+		return nil, fmt.Errorf("prepare request body failed: %w", err)
+	}
+	req, err := http.NewRequest(c.Request.Method, fullRequestURL, replayBody)
 	if err != nil {
 		return nil, fmt.Errorf("new request failed: %w", err)
 	}
@@ -340,7 +371,11 @@ func DoFormRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBod
 		return nil, fmt.Errorf("get request url failed: %w", err)
 	}
 	logger.LogDebug(c, "fullRequestURL: %s", fullRequestURL)
-	req, err := http.NewRequest(c.Request.Method, fullRequestURL, requestBody)
+	replayBody, err := makeReplayableBody(requestBody, info)
+	if err != nil {
+		return nil, fmt.Errorf("prepare request body failed: %w", err)
+	}
+	req, err := http.NewRequest(c.Request.Method, fullRequestURL, replayBody)
 	if err != nil {
 		return nil, fmt.Errorf("new request failed: %w", err)
 	}
@@ -537,15 +572,18 @@ func DoTaskApiRequest(a TaskAdaptor, c *gin.Context, info *common.RelayInfo, req
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest(c.Request.Method, fullRequestURL, requestBody)
+	replayBody, err := makeReplayableBody(requestBody, info)
+	if err != nil {
+		return nil, fmt.Errorf("prepare request body failed: %w", err)
+	}
+	req, err := http.NewRequest(c.Request.Method, fullRequestURL, replayBody)
 	if err != nil {
 		return nil, fmt.Errorf("new request failed: %w", err)
 	}
 	applyUpstreamContentLength(req, info)
-	req.GetBody = func() (io.ReadCloser, error) {
-		return io.NopCloser(requestBody), nil
-	}
-
+	// GetBody is auto-set by http.NewRequest when replayBody is *bytes.Reader
+	// (see makeReplayableBody); the old io.NopCloser(requestBody) override that
+	// returned an exhausted shared reader on retry is removed.
 	err = a.BuildRequestHeader(c, req, info)
 	if err != nil {
 		return nil, fmt.Errorf("setup request header failed: %w", err)

--- a/relay/channel/gemini/clean_function_parameters_test.go
+++ b/relay/channel/gemini/clean_function_parameters_test.go
@@ -1,0 +1,59 @@
+package gemini
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCleanFunctionParametersDropsUnsupportedKeywords verifies the allowlist-based
+// cleaner removes JSON-Schema keywords Gemini function_declarations rejects
+// (exclusiveMinimum, propertyNames, const) — including when nested inside anyOf.
+//
+// Canary once logged gemini 400s: "Unknown name "const" at '...any_of[1]'",
+// "Unknown name "exclusiveMinimum"...", "Unknown name "propertyNames"...".
+// This test pins that the cleaner drops them (standard json.Unmarshal yields
+// []interface{}/map[string]interface{}, so the anyOf type assertion + recursion
+// at relay-gemini.go:774-781 reaches and filters them).
+func TestCleanFunctionParametersDropsUnsupportedKeywords(t *testing.T) {
+	t.Parallel()
+
+	params := map[string]interface{}{
+		"type": "object",
+		"anyOf": []interface{}{
+			map[string]interface{}{"type": "string"},
+			map[string]interface{}{"const": "x", "type": "string"}, // const must be dropped, anyOf kept
+		},
+		"properties": map[string]interface{}{
+			"p": map[string]interface{}{
+				"type":             "integer",
+				"minimum":          0, // allowed, kept
+				"exclusiveMinimum": 0, // not in allowlist, dropped
+				"propertyNames":    map[string]interface{}{}, // dropped
+			},
+		},
+	}
+
+	cleaned := cleanFunctionParameters(params)
+	cm, ok := cleaned.(map[string]interface{})
+	require.True(t, ok)
+
+	// anyOf is in the allowlist → kept; its items are recursively cleaned.
+	anyOf, ok := cm["anyOf"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, anyOf, 2)
+	second, ok := anyOf[1].(map[string]interface{})
+	require.True(t, ok)
+	require.NotContains(t, second, "const", "const inside anyOf must be dropped")
+	// normalizeGeminiSchemaTypeAndNullable uppercases type strings (string→STRING).
+	require.Equal(t, "STRING", second["type"])
+
+	// Nested properties: minimum kept, exclusiveMinimum/propertyNames dropped.
+	props, ok := cm["properties"].(map[string]interface{})
+	require.True(t, ok)
+	p, ok := props["p"].(map[string]interface{})
+	require.True(t, ok)
+	require.Contains(t, p, "minimum")
+	require.NotContains(t, p, "exclusiveMinimum")
+	require.NotContains(t, p, "propertyNames")
+}

--- a/relay/channel/replayable_body_test.go
+++ b/relay/channel/replayable_body_test.go
@@ -1,0 +1,54 @@
+package channel
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/stretchr/testify/require"
+)
+
+// makeReplayableBody gates whether an upstream request body is buffered into RAM
+// so net/http can replay it on an HTTP/2 GOAWAY/PROTOCOL_ERROR mid-stream retry
+// (net/http auto-installs Request.GetBody for *bytes.Reader). Small bodies are
+// buffered; oversized/unknown-size bodies pass through unbuffered to avoid OOM.
+
+func TestMakeReplayableBody_BuffersSmallBodyAsBytesReader(t *testing.T) {
+	t.Parallel()
+	info := &relaycommon.RelayInfo{UpstreamRequestBodySize: 12}
+	body, err := makeReplayableBody(strings.NewReader(`{"model":"x"}`), info)
+	require.NoError(t, err)
+	br, ok := body.(*bytes.Reader)
+	require.True(t, ok, "small body must be buffered as *bytes.Reader so net/http auto-sets GetBody")
+	content, err := io.ReadAll(br)
+	require.NoError(t, err)
+	require.Equal(t, `{"model":"x"}`, string(content))
+}
+
+func TestMakeReplayableBody_PassesThroughOversizedBody(t *testing.T) {
+	t.Parallel()
+	original := strings.NewReader("oversized-body")
+	info := &relaycommon.RelayInfo{UpstreamRequestBodySize: replayBodyLimit + 1}
+	body, err := makeReplayableBody(original, info)
+	require.NoError(t, err)
+	require.Same(t, original, body, "oversized body must pass through unbuffered to avoid OOM")
+}
+
+func TestMakeReplayableBody_PassesThroughUnknownSize(t *testing.T) {
+	t.Parallel()
+	original := strings.NewReader("unknown-size")
+	info := &relaycommon.RelayInfo{UpstreamRequestBodySize: 0} // handler did not set size
+	body, err := makeReplayableBody(original, info)
+	require.NoError(t, err)
+	require.Same(t, original, body, "unknown-size body must pass through rather than buffer blindly")
+}
+
+func TestMakeReplayableBody_NilInfoPassesThrough(t *testing.T) {
+	t.Parallel()
+	original := strings.NewReader("x")
+	body, err := makeReplayableBody(original, nil)
+	require.NoError(t, err)
+	require.Same(t, original, body)
+}


### PR DESCRIPTION
## Problem

Customers using Claude Code (multi-window, concurrent) through the gateway get \`API error attempt 1/10\` (retry storm / perceived queueing) on models routed to the **tokenpony** upstream (\`api.tokenpony.cn\`). Root cause from canary logs (15 occurrences / 3h):

\`\`\`
do request failed: Post "https://api.tokenpony.cn/v1/chat/completions":
http2: Transport: cannot retry err [stream error: stream ID 3; PROTOCOL_ERROR; received from peer]
after Request.Body was written; define Request.GetBody to avoid this error
\`\`\`

tokenpony sends HTTP/2 GOAWAY / PROTOCOL_ERROR under concurrent load. Go's http2 transport wants to retry but \`Request.GetBody == nil\` (and the body was already written) → can't replay → \`do request failed\` → 500 → client retries → amplifies load.

Verified the error message itself points at the fix: *"define Request.GetBody to avoid this error"* = Go reached the retry path but couldn't replay the body.

## Fix

\`makeReplayableBody\` (**size-gated**): bodies whose known size is ≤ \`replayBodyLimit\` (1 MiB) are buffered into a \`*bytes.Reader\`, for which \`net/http.NewRequest\` auto-installs \`Request.GetBody\` (+ \`ContentLength\`) → the transport replays the body on retry.

Wired into \`DoApiRequest\`, \`DoFormRequest\`, \`DoTaskApiRequest\` (the three request builders; chat-completions hot path + form/task paths).

### Why size-gated, not unconditional buffer
An unconditional \`io.ReadAll\` would materialize **disk-backed / vision / image** bodies (inbound cap 128 MB) into RAM → heap spikes / OOM under concurrency. The gate uses the existing \`info.UpstreamRequestBodySize\` (set by all handlers): small/chat bodies (the common case) get replay; oversized bodies pass through unbuffered (trade retry-safety for OOM-safety).

### Also fixes \`DoTaskApiRequest\`'s broken GetBody
Its existing override \`req.GetBody = func() { return io.NopCloser(requestBody), nil }\` returned the **same exhausted shared reader** on every retry (and overwrote the correct GetBody \`NewRequest\` would auto-set for a \`*bytes.Reader\`). Removed — now goes through \`makeReplayableBody\` like the others.

## Caveat (reviewed, accepted)
The HTTP/2 retry path does **not** check idempotency, so a POST the upstream already received could be replayed. In practice tokenpony's error arrives **before response headers** (inference not completed), the blast radius is bounded (up to ~6 transport retries with backoff), and the status quo (500 → Claude Code's own retry loop) re-sends the request anyway. Do **not** layer an application-level retry on top.

## item 3 (separate gemini 400s) — verified, no production code
Canary also showed gemini-route 400s (\`function_declarations\` rejecting \`const\`/\`exclusiveMinimum\`/\`propertyNames\`, incl. inside \`anyOf\`). Added test confirming \`cleanFunctionParameters\` (allowlist) **already drops these** including nested in \`anyOf\` — so those 400s were stale/transient, not a cleaner gap. (A separate latent gap exists in \`removeAdditionalPropertiesWithDepth\` for \`response_schema\`, but that's not the observed path and not in scope here.)

## Tests
- \`relay/channel/replayable_body_test.go\` — 4 tests: buffers small body as \`*bytes.Reader\`; passes through oversized / unknown-size / nil-info.
- \`relay/channel/gemini/clean_function_parameters_test.go\` — drops const/exclusiveMinimum/propertyNames incl. in anyOf.
- \`relay/channel\`, \`gemini\`, \`openai\`, \`claude\` all green; full \`go build ./...\` + \`go vet\` clean.
- Pre-existing unrelated failure: \`relay/helper TestStreamScannerHandler_StreamStatus_ReplacesPreInitialized\` fails on clean lh-main too (stream-scanner, not this change).

## Deploy note
Canary \`new-api:lh-main\` image is a 2026-06-20 build (stale ~25 days). This PR's canary deploy = rebuild the image from lh-main + \`docker compose up -d new-api\`; e2e = concurrent glm-5.2 via ch9 tokenpony → \`docker logs new-api | grep "do request failed"\` should drop to ~0 (was 15/3h).