### PR TITLE
test(helper): fix stale StreamScanner test (Replaces→Preserves, pre-existing failure on lh-main)

### DIFF
--- a/relay/helper/stream_scanner_test.go
+++ b/relay/helper/stream_scanner_test.go
@@ -484,7 +484,13 @@ func TestStreamScannerHandler_StreamStatus_InitializedIfNil(t *testing.T) {
 	assert.NotNil(t, info.StreamStatus)
 }
 
-func TestStreamScannerHandler_StreamStatus_ReplacesPreInitialized(t *testing.T) {
+// TestStreamScannerHandler_StreamStatus_PreservesPreInitialized verifies the
+// handler PRESERVES a pre-existing StreamStatus (incl. its recorded errors)
+// rather than replacing it — it only creates a new StreamStatus when nil
+// (relay/helper/stream_scanner.go). Behavior changed from unconditional-replace
+// to preserve-if-nil in 48b379e4a (stabilize shared relay tests); this test was
+// updated to assert the current preserve semantics instead of the old replace.
+func TestStreamScannerHandler_StreamStatus_PreservesPreInitialized(t *testing.T) {
 	t.Parallel()
 
 	body := buildSSEBody(5)
@@ -496,5 +502,6 @@ func TestStreamScannerHandler_StreamStatus_ReplacesPreInitialized(t *testing.T) 
 	StreamScannerHandler(c, resp, info, func(data string, sr *StreamResult) {})
 
 	assert.Equal(t, relaycommon.StreamEndReasonDone, info.StreamStatus.EndReason)
-	assert.Equal(t, 0, info.StreamStatus.TotalErrorCount())
+	// The pre-existing error is preserved (handler keeps a non-nil StreamStatus).
+	assert.Equal(t, 1, info.StreamStatus.TotalErrorCount())
 }


### PR DESCRIPTION
## Problem

\`TestStreamScannerHandler_StreamStatus_ReplacesPreInitialized\` fails on **clean lh-main** (pre-existing, unrelated to #16). Discovered while running \`go test ./relay/...\` for the GetBody fix.

## Root cause (git-verified)

Commit **48b379e4a** ("fix: 稳定共享 relay 测试失败项") deliberately changed \`StreamScannerHandler\` (\`relay/helper/stream_scanner.go\`):

\`\`\`diff
-	// 无条件新建 StreamStatus
-	info.StreamStatus = relaycommon.NewStreamStatus()
+	// Preserve existing StreamStatus if already set (e.g. with pre-existing errors)
+	if info.StreamStatus == nil {
+		info.StreamStatus = relaycommon.NewStreamStatus()
+	}
\`\`\`

i.e. unconditional-**replace** → **preserve-if-nil**. The handler now KEEPS a pre-existing StreamStatus (and its recorded errors) instead of resetting it.

The test still asserted the OLD replace behavior — \`TotalErrorCount() == 0\` after pre-setting an error — so it went stale when the impl intentionally changed.

## Fix

Renamed \`...ReplacesPreInitialized\` → \`...PreservesPreInitialized\` and flipped the assertion to \`TotalErrorCount() == 1\` (pre-existing error is preserved), with a comment documenting the behavior change + the 48b379e4a commit that drove it.

This is **not** a "change the test to make it pass" hack: git history confirms the impl change was deliberate (with a rationale comment), and the test is corrected to track the intended semantics.

## Verified
- \`go test ./relay/helper/\` green (was the only failing package).
- \`go test ./relay/... ./common/...\` fully green — zero failures across all relay packages now.